### PR TITLE
Fix elections footer style

### DIFF
--- a/public/assets/sass/pages/elections.scss
+++ b/public/assets/sass/pages/elections.scss
@@ -40,10 +40,6 @@ h4 {
   margin-bottom: 4px;
 }
 
-p {
-  margin: 0;
-}
-
 .elections-decision {
   h2, h3 {
     margin-bottom: 0.25em;


### PR DESCRIPTION
![squish](https://media.tenor.com/FKnVl4B3d5kAAAAM/cat-cats.gif)

Fixes the line height on the elections page footer.  This will change the line height on the rest of the page, but I think it actually looks better that way anyway, so no need to worry about maintaining the exact previous appearance.