### PR TITLE
Volunteer at MathSoc Page!

### DIFF
--- a/public/assets/js/collapsible.js
+++ b/public/assets/js/collapsible.js
@@ -1,0 +1,16 @@
+var collapsible = document.getElementsByClassName("collapsible-button");
+var i;
+
+for (i = 0; i < collapsible.length; i++) {
+    collapsible[i].addEventListener("click", function() {
+      this.classList.toggle("active");
+      var content = this.nextElementSibling;
+      if (content.style.maxHeight){
+        content.style.maxHeight = null;
+        content.style.paddingBottom = null;
+      } else {
+        content.style.maxHeight = content.scrollHeight + "px";
+        content.style.paddingBottom = "18px";
+      }
+    });
+  }

--- a/public/assets/js/collapsible.js
+++ b/public/assets/js/collapsible.js
@@ -1,7 +1,7 @@
 var collapsible = document.getElementsByClassName("collapsible-button");
-var i;
 
-for (i = 0; i < collapsible.length; i++) {
+
+for (let i = 0; i < collapsible.length; i++) {
     collapsible[i].addEventListener("click", function() {
       this.classList.toggle("active");
       var content = this.nextElementSibling;

--- a/public/assets/sass/mixins/_collapsible.scss
+++ b/public/assets/sass/mixins/_collapsible.scss
@@ -1,0 +1,47 @@
+@import '../util/_sass-mixins';
+
+.collapsible-button {
+    background-color: #fff;
+    color: #444;
+    cursor: pointer;
+    padding: 18px;
+    width: 100%;
+    border: none;
+    text-align: left;
+    outline: none;
+    font-size: 20px;
+    border-top: 2px solid;
+
+    ::after {
+        content: '\02795'; /* Unicode character for "plus" sign (+) */
+        font-size: 13px;
+        color: white;
+        float: right;
+        margin-left: 5px;
+    }
+
+    .active:after {
+        content: "\2796"; /* Unicode character for "minus" sign (-) */
+    }
+}
+
+
+.collapsible-content {
+    padding: 0 18px;
+    background-color: white;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.2s ease-out;
+}
+  
+.collapsible-button:after {
+    content: '\02795'; /* Unicode character for "plus" sign (+) */
+    font-size: 13px;
+    color: white;
+    float: right;
+    margin-left: 5px;
+}
+
+.active:after {
+    content: "\2796"; /* Unicode character for "minus" sign (-) */
+}

--- a/public/assets/sass/pages/volunteer.scss
+++ b/public/assets/sass/pages/volunteer.scss
@@ -1,0 +1,28 @@
+@import '../mixins/banner-image';
+@import '../mixins/collapsible';
+
+section {
+    max-width: var(--content-width);
+    margin: 30px auto;
+
+    h1 {
+        margin: 0;
+        font-size: 3em;
+      }
+}
+
+h2 {
+    font-family: var(--title-font);
+    font-size: 1.6em;
+  }
+  
+h3 {
+    font-family: var(--title-font);
+    font-size: 1.4em;
+}
+  
+h4 {
+    font-family: var(--title-font);
+    font-size: 1.2em;
+    margin-bottom: 4px;
+}

--- a/server/config/navbar.json
+++ b/server/config/navbar.json
@@ -4,7 +4,7 @@
         "children":[
             {
                 "title": "Volunteer at MathSoc",
-                "ref": "/"
+                "ref": "/volunteer-at-mathsoc"
             },
             {
                 "title": "Math Community",

--- a/server/data/volunteer.json
+++ b/server/data/volunteer.json
@@ -92,26 +92,122 @@
             "roles": [
                 {
                     "title": "Deputy Vice President, Academic",
-                    "description": "",
-                    "link": "/"
+                    "description": "The <em>Deputy Vice President, Academic</em> will assist the <em>Vice President, Academic</em> and advocate on special topics as the need arises. This role will involve some secretarial work but will generally be an advocacy role.<br></br><strong>Responsibilities</strong><ul><li>Assist the Vice President, Academic as needed.</li><li>Help the Vice President, Academic respond to any issues impacting undergraduate Math students.</li></ul><strong>Requirements</strong><ul><li>Be an undergraduate math student.</li><li>Be in Waterloo.</li><li>Good at writing and communication</li></ul><strong>Expected commitment</strong><ul><li>About 1 - 5 hours per week, with opportunities to take on additional work if desired.</li></ul>" ,
+                    "link": ""
                 },
                 {
                     "title": "Academic Events Director",
-                    "description": "",
+                    "description": "<p>The&nbsp;<em>Academic Events Director</em>&nbsp;will work with the&nbsp;<em>Vice President, Academic</em>, and is responsible for running two academic events in the spring term.</p> <p><strong>Responsibilities</strong></p> <ul> <li>Encourage students to volunteer for academic events.</li> <li>Organizing and facilitating the events.</li> <li>Working with the Vice President, Communications to market the events.</li> </ul> <p><strong>Requirements</strong></p> <ul> <li>Be an undergraduate math student.</li> <li>Be in Waterloo.</li> <li>Have experience in organizing events.</li> </ul> <p><strong>Expected commitment</strong></p> <ul> <li>About 10 hours per week during the preparation of academic events.</li> <li>Little to no work after events are run.</li> </ul> ",
                     "link": "/"
                 },
                 {
                     "title": "Exam Bank Director",
-                    "description": "",
+                    "description": "<p>The&nbsp;<em>Exam Bank Director</em>&nbsp;will work with the&nbsp;<em>Vice President, Academic,</em>&nbsp;and is responsible for maintaining the Exam Bank and facilitating the submission and approval of new exams.</p> <p><strong>Responsibilities</strong></p> <ul> <li>Managing the Exam Bank system.</li> <li>Finding courses that MathSoc does not have any exams in its Exam Bank for.</li> <li>Reaching out to current and past instructors of courses to add their exams to the Exam Bank.</li> </ul> <p><strong>Requirements</strong></p> <ul> <li>Be an undergraduate math student.</li> <li>Be in Waterloo.</li> <li>Good at communication.</li> </ul> <p><strong>Expected commitment</strong></p> <ul> <li>0&ndash;2 hours per week.</li> </ul>",
                     "link": "/"
                 },
                 {
                     "title": "Textbook Library Directory",
-                    "description": "",
+                    "description": "<p>The&nbsp;<em>Textbook Library Director</em>&nbsp;will work with the&nbsp;<em>Vice President, Academic,</em>&nbsp;and is responsible for maintaining MathSoc&rsquo;s Textbook Library.</p> <p><strong>Responsibilities</strong></p> <ul> <li>Ensure that MathSoc has sufficient and up-to-date textbooks for core Math Faculty courses.</li> </ul> <p><strong>Requirements</strong></p> <ul> <li>Be an undergraduate math student.</li> <li>Be in Waterloo.</li> </ul> <p><strong>Expected commitment</strong></p> <ul> <li>0&ndash;2 hours per week.</li> </ul> ",
                     "link": "/"
                 }
             ]
-        } 
+        },
+        {
+            "name": "President Directors",
+            "roles": [
+                {
+                    "title": "Presidential Assistant",
+                    "description": "<p>The Presidential Assistant will work closely with the president and understand what the day-to-day of the President looks like. They will also assist and suggest solutions to Society&rsquo;s ongoing or previous problems and issues. We are looking for an undergraduate student with excellent writing and communication skills. We believe this position can offer the volunteer training, support, and immense experience. Preference will be given to those who can work&nbsp;<strong>in-person</strong>.</p>",
+                    "link": ""
+                },
+                {
+                    "title": "Director of First Year Affairs",
+                    "description": "<p>The Director of First Year Affairs is responsible for chairing the Committee of First Year Affairs (CFYA). The CFYA is to encourage greater participation by first year students in the Society, to ensure that the concerns of first year students are adequately represented within the Society and the Faculty, and to provide a structure promoting greater communication between first-year and upper-year students. The Director reports to and is responsible to the President; have the power to appoint committee members to administer the various aspects of the Committee. More information about this role can be found in&nbsp;<a href='https://services.mathsoc.uwaterloo.ca/media/documents/Policies/MathSoc_Policies_-_2019-05-14.pdf#section.17'>Policy 17</a>.</p> ",
+                    "link": ""
+                },
+                {
+                    "title": "Mental Health Director",
+                    "description": "The Mental Health Director(s) will primarily work on the mental health blog, creating posts and gathering posts from students who submit blogs. They will ensure MathSoc Office is stocked with proper campus wellness and mental health resources. The Mental Health Director(s) will also organize and implement the delivery of care packages for the fall term as well as ensuring campus resources regarding mental health and wellness are communicated to all Math students.",
+                    "link": ""
+                }
+            ]
+        },
+        {
+            "name": "MathSoc Executive Team",
+            "subheader": "Please ensure that you have read the MathSoc bylaws and policies before applying for any of the below roles, especially Bylaw 8.",
+            "roles": [
+                {
+                    "title": "President",
+                    "description": "<p>The President is the chief executive of the Society. They organize and run the general meeting, coordinate meetings between the Executive team and various other parties. The President is expected to present at most MathSoc events and to meet with each Club and Service at least once a term. More information about this role can be found in&nbsp;<a href=\"https://mathsoc.uwaterloo.ca/wp-content/uploads/bylaws-public.pdf\">Bylaw 8.3</a>&nbsp;and&nbsp;<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Policies/MathSoc_Policies_-_2019-05-14.pdf#section.25\">Policy 25&nbsp;</a>.</p> <p>The current President can be reached at&nbsp;<a href=\"mailto:president@mathsoc.uwaterloo.ca\">president@mathsoc.uwaterloo.ca</a></p> ",
+                    "link": ""
+                },
+                {
+                    "title": "Vice President, Finance",
+                    "description": "",
+                    "link": ""
+                },
+                {
+                    "title": "Vice President, Operations",
+                    "description": "",
+                    "link": ""
+                },
+                {
+                    "title": "Vice President, Internal",
+                    "description": "",
+                    "link": ""
+                },
+                {
+                    "title": "Vice President, Academic",
+                    "description": "",
+                    "link": ""
+                },
+                {
+                    "title": "Vice President, Communications",
+                    "description": "",
+                    "link": ""
+                }
+            ]
+        },
+        {
+            "name": "MathSoc Council",
+            "roles": [
+                {
+                    "title": "Program Representative",
+                    "description": "",
+                    "link": ""
+                },
+                {
+                    "title": "First Year Representative",
+                    "description": "",
+                    "link": ""
+                },
+                {
+                    "title": "Secretary",
+                    "description": "",
+                    "link": ""
+                },
+                {
+                    "title": "Speaker",
+                    "description": "",
+                    "link": ""
+                }
+            ]
+        },
+        {
+            "name": "MathSoc Board of Directors",
+            "roles": [
+                {
+                    "title": "At-large Director",
+                    "description": "",
+                    "link": ""
+                },
+                {
+                    "title": "Pro-tempore Board Directory",
+                    "description": "",
+                    "link": ""
+                }
+            ]
+        }
     ]
 
 }

--- a/server/data/volunteer.json
+++ b/server/data/volunteer.json
@@ -143,27 +143,27 @@
                 },
                 {
                     "title": "Vice President, Finance",
-                    "description": "",
+                    "description": "<p>The Vice President, Finance (VPF), is responsible for the financial affairs of the society. They work closely with the WUSA Accountant to ensure that MathSoc is following proper procedures. They are also responsible for ensuring that clubs and services receive reimbursements in a timely manner. More information about this role can be found in&nbsp;<a href=\"https://mathsoc.uwaterloo.ca/wp-content/uploads/bylaws-public.pdf\">Bylaw 8.4</a>&nbsp;and&nbsp;<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Policies/MathSoc_Policies_-_2019-05-14.pdf#section.25\">Policy 25&nbsp;</a>.<br /> <br /> The current VPF can be reached at&nbsp;<a href=\"mailto:vpf@mathsoc.uwaterloo.ca\">vpf@mathsoc.uwaterloo.ca</a></p> ",
                     "link": ""
                 },
                 {
                     "title": "Vice President, Operations",
-                    "description": "",
+                    "description": "<p>The Vice President Operations (VPO), is responsible for the MathSoc office, equipment and room bookings as well as the MathSoc website. More information about this role can be found in&nbsp;<a href=\"https://mathsoc.uwaterloo.ca/wp-content/uploads/bylaws-public.pdf\">Bylaw 8.5</a>&nbsp;and&nbsp;<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Policies/MathSoc_Policies_-_2019-05-14.pdf#section.25\">Policy 25&nbsp;</a>.<br /> <br /> The current VPO can be reached at&nbsp;<a href=\"mailto:vpo@mathsoc.uwaterloo.ca\">vpo@mathsoc.uwaterloo.ca</a></p> ",
                     "link": ""
                 },
                 {
                     "title": "Vice President, Internal",
-                    "description": "",
+                    "description": "<p>The Vice President, Internal (VPI), is responsible for filling out event forms for all MathSoc Events as well as helping others fill out the required forms properly. They are expected to be present at most MathSoc events and to provide advertising for all MathSoc events as well as run important events like Clubs Day at the start of term, and Pi Day. More information about this role can be found in&nbsp;<a href=\"https://mathsoc.uwaterloo.ca/wp-content/uploads/bylaws-public.pdf\">Bylaw 8.6</a>&nbsp;and&nbsp;<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Policies/MathSoc_Policies_-_2019-05-14.pdf#section.25\">Policy 25</a>.<br /> <br /> The current VPI can be reached at&nbsp;<a href=\"mailto:vpi@mathsoc.uwaterloo.ca\">vpi@mathsoc.uwaterloo.ca</a></p>",
                     "link": ""
                 },
                 {
                     "title": "Vice President, Academic",
-                    "description": "",
+                    "description": "<p>The Vice President, Academics (VPA), is responsible for running at least two academic events of some sort over the term. They are also expected to attend all required meeting and solicit student feedback about upcoming academic changes. More information about this role can be found in&nbsp;<a href=\"https://mathsoc.uwaterloo.ca/wp-content/uploads/bylaws-public.pdf\">Bylaw 8.7</a>&nbsp;and&nbsp;<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Policies/MathSoc_Policies_-_2019-05-14.pdf#section.25\">Policy 25</a>.</p> <p>The current VPA can be reached at&nbsp;<a href=\"mailto:vpa@mathsoc.uwaterloo.ca\">vpa@mathsoc.uwaterloo.ca</a></p> ",
                     "link": ""
                 },
                 {
                     "title": "Vice President, Communications",
-                    "description": "",
+                    "description": "<p>The Vice President, Communications (VPC), is responsible for providing advertising for all MathSoc events through social media and poster advertisement. They are also in charge of sending out communication to students via mass emails and the MathSoc website. More information about this role can be found in&nbsp;<a href=\"https://mathsoc.uwaterloo.ca/wp-content/uploads/bylaws-public.pdf\">Bylaw 8.8</a>&nbsp;and&nbsp;<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Policies/MathSoc_Policies_-_2019-05-14.pdf#section.25\">Policy 25</a>.</p> <p>The current VPC can be reached at&nbsp;<a href=\"mailto:vpc@mathsoc.uwaterloo.ca\">vpc@mathsoc.uwaterloo.ca</a></p> ",
                     "link": ""
                 }
             ]
@@ -173,22 +173,22 @@
             "roles": [
                 {
                     "title": "Program Representative",
-                    "description": "",
+                    "description": "<p>The Council is comprised of up to 35 voting members. Council represents the members of the Society by setting advocacy priorities, approving the budgets of clubs and executives as well as providing a voice for students (<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Bylaws/MathSoc_Bylaws_-_2019-04-18.pdf#subsection.7.1\">Bylaw 7.1</a>). Please note that first years are generally not eligible to be Program Representatives (<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Bylaws/MathSoc_Bylaws_-_2019-04-18.pdf#subsection.7.3\">Bylaw 7.3</a>).</p> <p>See&nbsp;<a href=\"https://mathsoc.uwaterloo.ca/elections/\">https://mathsoc.uwaterloo.ca/elections/</a>&nbsp;to see the Fall 2021 representatives. Please visit our&nbsp;<a href=\"https://mathsoc.uwaterloo.ca/elections/\">Election</a>&nbsp;page for more information about the by-election!</p> ",
                     "link": ""
                 },
                 {
                     "title": "First Year Representative",
-                    "description": "",
+                    "description": "<p>While also representing first year students on Council, First Year Representatives are all part of the Committee of First Year Affairs (CFYA) (<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Policies/MathSoc_Policies_-_2019-05-14.pdf#section.17\">Policy 17</a>). CFYA is tasked with encouraging greater participation by first year students in MathSoc, that concerns of first year students are heard and to provide communication between first year and upper year students. In previous years this Committee has run events like &ldquo;Board Games and Bubble Tea&rdquo;. First year representatives hold the position of First Year Representative until they either finish first year or until the end of the following Spring term (<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Bylaws/MathSoc_Bylaws_-_2019-04-18.pdf#subsubsection.7.3.2\">Bylaw 7.3.2</a>).</p> ",
                     "link": ""
                 },
                 {
                     "title": "Secretary",
-                    "description": "",
+                    "description": "<p>The Secretary has the following duties:</p> <ol> <li>Record attendance of Council meetings, including when a member is more than one half-hour late for a meeting and if they sent notice of their absence;</li> <li>Distribute minutes of each Council or General meeting in a timely manner after that meeting;</li> <li>Report to Council when a Councillor is failing to meet the requirements of office.</li> </ol> <p>Refer to (<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Bylaws/MathSoc_Bylaws_-_2019-04-18.pdf#subsection.7.12.2\">Bylaw 7.12.2</a>) for more information.&nbsp;</p> ",
                     "link": ""
                 },
                 {
                     "title": "Speaker",
-                    "description": "",
+                    "description": "<p>The Speaker has the following duties:</p> <ol> <li>Serve as the presiding officer of Council;</li> <li>Work with the Chair of the Board of Directors to interpret this and any other governing documents of the Society, subject to appeal to Council, the Board of Directors, or a general meeting;</li> <li>Arrange for and advertise meetings of Council;</li> <li>Ensure that all Council members have access to the official notice forum if any; and</li> <li>Ensure that Council meetings are called regularly.</li> </ol> <p>Refer to (<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Bylaws/MathSoc_Bylaws_-_2019-04-18.pdf#subsection.7.12.1\">Bylaw 7.12.1</a>) for more information.&nbsp;</p> ",
                     "link": ""
                 }
             ]
@@ -198,16 +198,17 @@
             "roles": [
                 {
                     "title": "At-large Director",
-                    "description": "",
+                    "description": "<p>The Board of Directors is comprised of up to 14 voting members and is responsible for the management of the legal, financial, and human resource concerns of the organization as well as long term planning (<a href=\"https://services.mathsoc.uwaterloo.ca/media/documents/Bylaws/MathSoc_Bylaws_-_2019-04-18.pdf#subsection.6.1\">Bylaw 6.1</a>). If interested in this position we recommend checking out Bylaw 6 to learn more about the Board of Directors.</p> <p>Each term there are 2 at-large representatives elected for the following year as well as potentially shorter terms depending on availability. Applications will open in the second month of term. If you would like an email reminder when applications open please email vpo@mathsoc.uwaterloo.ca.</p> ",
                     "link": ""
                 },
                 {
                     "title": "Pro-tempore Board Directory",
-                    "description": "",
+                    "description": "A 4-month At-large position to sit on MathSoc’s Board of Directors. MathSoc is looking for experienced individuals who are passionate about the Society and interested in providing their perspective to help the Society’s long-term planning.",
                     "link": ""
                 }
             ]
         }
-    ]
-
+    ],
+    "clubsTitle": "Clubs",
+    "clubsSubheader" : "<p>To ensure the most up-to date information to volunteer with a club checkout their&nbsp;<a href=\"https://mathsoc.uwaterloo.ca/clubs/\">websites</a>, visit their office or send them an email.</p> "
 }

--- a/server/data/volunteer.json
+++ b/server/data/volunteer.json
@@ -1,0 +1,117 @@
+{
+    "title": "Volunteer with MathSoc!",
+    "subtext": "Volunteering with MathSoc is a great way to meet other people in your faculty. While some positions are time sensitive we welcome applications at anytime. If you have questions about a role we recommend sending the corresponding VP or club an email. If a position that you are interested in is not currently open and you wish to receive a notification when it opens please email the VPC at vpc@mathsoc.uwaterloo.ca about what positions you are interested in and ensure to check this page regularly. We look forward to meeting you!",
+    "teams": [
+        {
+            "name": "VP Operations Directors",
+            "roles": [
+                {
+                    "title": "Office Worker",
+                    "description": "As an office worker, you would be working in the MathSoc Office (MC 3038) to help students sign-out rental items, sell novelties and supplies, and aid students looking for help within the office. Office shifts are flexible and are low in required time commitment, and there will be an office manager to guide you. You are free to work on personal tasks when there is no one looking for assistance, and will get access to our stash of free office worker snacks. Please note this is an in-person position.",
+                    "link": "/"
+                },
+                {
+                    "title": "Office Manager",
+                    "description": "As an office manager, you would be working in the MathSoc Office (MC 3038) to help students sign-out rental items, sell novelties and supplies, and aid students looking for help within the office, similar to an office worker. Additional responsibilities might include opening and closing the office, helping with locker issues and assisting office workers. Manager shifts are flexible and managers get access to exclusive office manager snacks and drinks. Please note this is an in-person position.",
+                    "link": "/"
+                },
+                {
+                    "title": "Novelties Director",
+                    "description": "The Novelties Director will have the opportunity to design Math novelties. In the past, directors have designed shirts, socks, hats, hoodies, and pins among other things. If you would like to flex your creativity and create new Math related things, please apply!",
+                    "link": "/"
+                },
+                {
+                    "title":"Games Director",
+                    "description": "Games Director duties include maintaining the board game collection. They also help out with buying new games for our collection, based on suggestions from the community, and help with maintaining a full games inventory that is usually done once a year.",
+                    "link": "/"
+                }
+            ]
+        },
+        {
+            "name": "VP Finance Directors",
+            "roles": [
+                {
+                    "title": "Finance Directors",
+                    "description": "Finance directors will work alongside the VP Finance to assist with processing cheque requests, and any other ad hoc duties given to them. Please note that this is an in-person position.",
+                    "link": "/"
+                }
+            ]
+        },
+        {
+            "name": "VP Internal Directors",
+            "roles": [
+                {
+                    "title": "Game Night Directors",
+                    "description": "As a games night director, you will be in charge of planning the weekly games night as well as the Party with Profs event alongside the VP Internal. Please note that this is an in-person position.",
+                    "link": "/"
+                },
+                {
+                    "title": "Clubs Director",
+                    "description": "As the clubs director, you will be responsible for all communication between MathSoc clubs on a regular basis. You will also be in charge of raising any of their concerns or questions with the VP Internal. Applications are currently closed.",
+                    "link": "/"
+                },
+                {
+                    "title": "Event Coordinators",
+                    "description": "Event Coordinators work alongside the VP Internal to plan faculty-wide events such as Pi Day, Halloween, and more to come! Please note that this is an in-person position.",
+                    "link": "/"
+                },
+                {
+                    "title": "Volunteers",
+                    "description": "General Volunteers work with the VP Internal help out and set-up events during the day. Volunteers will be needed on an on-call basis, and will be notified one week before the event to indicate your time shift. Please note that this is an in-person position.",
+                    "link": "/"
+                }
+            ]
+        },
+        {
+            "name": "VP Communications Directors",
+            "roles": [
+                {
+                    "title": "Marketing Directors",
+                    "description": "As a marketing director, you will be expected to create graphics using Canva, for both our social media pages and our poster boards! Prior experience with this tool is an asset!",
+                    "link": "/"
+                },
+                {
+                    "title": "Postings Director",
+                    "description": "As the postings director, you will be responsible for managing MathSoc’s poster boards on (MC & DC). Please note this is an in-person position.",
+                    "link": "/"
+                },
+                {
+                    "title": "Photographer",
+                    "description": "Photographers help out with taking pictures of our events, the student body, and our society as a whole! While prior experience is an asset, it is not required and we do own a camera so equipment is not mandatory!",
+                    "link": "/"
+                },
+                {
+                    "title": "Web Developers",
+                    "description": "Web Developers help with maintaining, improving, and monitoring the MathSoc website! Prior experience with HTML and web design is an asset, but not mandatory!",
+                    "link": "/"
+                }
+            ]
+        },
+        {
+            "name": "VP Academic Directors",
+            "roles": [
+                {
+                    "title": "Deputy Vice President, Academic",
+                    "description": "",
+                    "link": "/"
+                },
+                {
+                    "title": "Academic Events Director",
+                    "description": "",
+                    "link": "/"
+                },
+                {
+                    "title": "Exam Bank Director",
+                    "description": "",
+                    "link": "/"
+                },
+                {
+                    "title": "Textbook Library Directory",
+                    "description": "",
+                    "link": "/"
+                }
+            ]
+        } 
+    ]
+
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,6 +3,7 @@ const navItems = require('../config/navbar.json');
 const footer = require('../config/footer.json');
 const electionsData = require('../data/elections.json');
 const wellnessData = require('../data/wellness.json');
+const volunteerData = require('../data/volunteer.json');
 
 router.get('/', async (req, res) => {
     res.render('pages/home', {navItems: navItems, footer: footer});
@@ -14,6 +15,10 @@ router.get('/elections', async (req, res) => {
 
 router.get('/mental-wellness', async (req, res) => {
   res.render('pages/resources/mental-wellness', {navItems: navItems, footer: footer, wellness: wellnessData});
+})
+
+router.get('/volunteer-at-mathsoc', async (req, res) => {
+  res.render('pages/get-involved/volunteer.pug', {navItems: navItems, footer: footer, volunteer: volunteerData});
 })
 
 module.exports = router;

--- a/views/mixins/components.pug
+++ b/views/mixins/components.pug
@@ -7,4 +7,13 @@ mixin homePageCard(caption, imgSource, imgText)
                 p=imgText
         p=caption
 
+mixin collapsible(title, content, link)
+    button(type="button" class="collapsible-button" value="" + title + "")= title
+    div(class="collapsible-content")
+        p=content
+        if link.length != ""
+            a(href=link) Apply Here!
+        else
+            p Applications are currently closed for this role. 
+
         

--- a/views/mixins/components.pug
+++ b/views/mixins/components.pug
@@ -10,8 +10,8 @@ mixin homePageCard(caption, imgSource, imgText)
 mixin collapsible(title, content, link)
     button(type="button" class="collapsible-button" value="" + title + "")= title
     div(class="collapsible-content")
-        p=content
-        if link.length != ""
+        p!=content
+        if link != ""
             a(href=link) Apply Here!
         else
             p Applications are currently closed for this role. 

--- a/views/pages/get-involved/volunteer.pug
+++ b/views/pages/get-involved/volunteer.pug
@@ -22,6 +22,7 @@ html(lang="en")
                         p #{team.subheader}
                     each role in team.roles
                         +collapsible(role.title, role.description, role.link)
-
+                h1 #{volunteer.clubsTitle}
+                p !{volunteer.clubsSubheader}
         include /views/partials/footer.pug
         

--- a/views/pages/get-involved/volunteer.pug
+++ b/views/pages/get-involved/volunteer.pug
@@ -1,0 +1,28 @@
+include /views/mixins/banner-image.pug
+include /views/mixins/components.pug
+
+doctype html 
+html(lang="en")
+    head 
+        title Volunteer at MathSoc &#8211; MathSoc
+        include /views/partials/header.pug
+        link(href="/assets/css/pages/volunteer.css" rel="stylesheet")
+        script(src="/assets/js/collapsible.js" defer)
+
+    body
+        include /views/partials/navbar.pug
+        +banner-image("/assets/img/banners/mathsoc-wall.jpeg")
+        div(class="content")
+            section(class="white")
+                h1 #{volunteer.title}
+                p #{volunteer.subtext}
+                each team in volunteer.teams
+                    h3 #{team.name}
+                    each role in team.roles
+                        if role.link != ""
+                            +collapsible(role.title, role.description, role.link)
+                        else 
+                            +collapsible
+
+        include /views/partials/footer.pug
+        

--- a/views/pages/get-involved/volunteer.pug
+++ b/views/pages/get-involved/volunteer.pug
@@ -18,11 +18,10 @@ html(lang="en")
                 p #{volunteer.subtext}
                 each team in volunteer.teams
                     h3 #{team.name}
+                    if team.subheader != ""
+                        p #{team.subheader}
                     each role in team.roles
-                        if role.link != ""
-                            +collapsible(role.title, role.description, role.link)
-                        else 
-                            +collapsible
+                        +collapsible(role.title, role.description, role.link)
 
         include /views/partials/footer.pug
         


### PR DESCRIPTION
Should hopefully close #17 

You might see some HTML strings in the description fields - these are there on purpose. Ideally, we should be able to allow the content writers of these pages to use rich-text editors, that can be converted into HTML strings to display to the website exactly as they were written and intended to be seen. These editors can be implemented into the CMS of this website.

You can test it by running the ```volunteer-mathsoc``` branch locally and going to the url ```http://localhost:3000/volunteer-at-mathsoc``` 
