### PR TITLE
Small wellness page design changes + more links

### DIFF
--- a/public/assets/sass/pages/wellness.scss
+++ b/public/assets/sass/pages/wellness.scss
@@ -14,13 +14,12 @@ section {
     h1 {
         font-family: var(--title-font);
         font-size: 3rem;
-        font-weight: 200;
+        color: var(--accent-colour-1);
     }
 
     h2 {
         font-family: var(--title-font);
         font-size: 1.4em;
-        font-weight: 200;
     }
 
     li {

--- a/server/data/resources/mental-wellness.json
+++ b/server/data/resources/mental-wellness.json
@@ -18,24 +18,24 @@
         {
             "title": "Health Services",
             "text": ["Health Services is a facility located across the creek from the Student Life Centre, 519-888-4096."],
-            "link": ""
+            "link": "https://uwaterloo.ca/campus-wellness/health-services"
         }
     ],
     "offCampusChildren": [
         {
             "title": "Good2Talk (24/7)",
             "text": ["Free confidential help line for post-secondary students. Phone: 1-866-925-5454"],
-            "link": ""
+            "link": "https://good2talk.ca/ontario/"
         },
         {
             "title": "Here 24/7",
             "text": ["Mental Health and Crisis Service Team. Phone: 1-844-437-3247"],
-            "link": ""
+            "link": "https://here247.ca/"
         },
         {
             "title": "OK2BME",
             "text": ["A set of support services for lesbian, gay, bisexual, transgender or questioning teens in Waterloo. Phone: 519-884-0000 extension 213"],
-            "link": ""
+            "link": "https://ok2bme.ca/"
         }
     ]
 }


### PR DESCRIPTION
This pr just changes a few things on the mental wellness page.
The header is now pink, and there are more links added (for all the missing links in the section). 