### PR TITLE
Mitigate pop-in

### DIFF
--- a/public/assets/sass/carousel.scss
+++ b/public/assets/sass/carousel.scss
@@ -4,7 +4,7 @@
   min-width: 100%;
   position: relative;
   margin: auto;
-  max-height: 400px;
+  height: 400px;
   overflow: hidden;
 
   .mySlides {

--- a/public/assets/sass/util/_variables.scss
+++ b/public/assets/sass/util/_variables.scss
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Zilla+Slab:ital,wght@0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap');
-
 // Colours
 :root {
   --background-colour: #fff;

--- a/views/partials/header.pug
+++ b/views/partials/header.pug
@@ -1,13 +1,22 @@
 head
-    meta(charset="UTF-8")
-    meta(http-equiv="X-UA-Compatible", content="IE=edge")
-    meta(name="viewport", content="width=device-width, initial-scale=1.0")
-    link(href="/assets/css/main.css", rel="stylesheet")
-    link(href='/assets/css/navbar.css' rel="stylesheet")
-    link(href="/assets/css/footer.css" rel="stylesheet")
-    link(href="/assets/img/icons/favicon.svg" rel="icon")
-    block styles
-    script(src="/assets/js/navbar.js" defer)
-    block scripts
-    block title
-        title=title + " \u2013 Mathsoc" 
+  meta(charset="UTF-8")
+  meta(http-equiv="X-UA-Compatible" content="IE=edge")
+  meta(name="viewport" content="width=device-width, initial-scale=1.0")
+  
+  block title
+    title=title + " \u2013 Mathsoc" 
+
+  link(rel="preconnect" href="https://fonts.googleapis.com")
+  link(rel="preconnect" href="https://fonts.gstatic.com" crossorigin)
+  - const googleFontsLink = "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Zilla+Slab:ital,wght@0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=block"; 
+  link(rel="preload" as="style" href=googleFontsLink)
+  link(href=googleFontsLink rel="stylesheet")
+  
+  link(href="/assets/css/main.css" rel="stylesheet")
+  link(href='/assets/css/navbar.css' rel="stylesheet")
+  link(href="/assets/css/footer.css" rel="stylesheet")
+  link(href="/assets/img/icons/favicon.svg" rel="icon")
+  block styles
+  
+  script(src="/assets/js/navbar.js" defer)
+  block scripts


### PR DESCRIPTION
![popcat](https://media.tenor.com/BT8I5b35oMQAAAAM/oatmeal-meme.gif)

Helps with the visible resource loading by tweaking a few things:
 * Changes our Google Fonts link to use `display=block` instead of `display=swap`.  This changes the font face's behaviour to render as invisible until the font is loaded, rather than immediately using the first available fallback font.  This is the most important change affecting pop-in.  

   In the current state, we have all of our text render in a fallback font, then when our Google Font loads in with a different font width, the page updates to use that font, causing many page elements to shift around to accomodate the new text sizing.  Instead, we now first render the text now as invisible, wait for the font to load, then populate the text onto the screen.  This presents a cleaner experience to the user.
   * Worth noting: `display=block` has an internal window of time until it uses the fallback font anyway.  This means that in the event that Google Fonts's servers are struck by a meteorite, MathSoc's site won't be entirely without text - it'll just take an extra few seconds to load.
 * Adds a `preconnect` to Google Fonts in the header, allowing the connection to Google to be prepared in advance of the font call
 * Reorders the load order in the header
 * Changes the homepage carousel to use a fixed height, such that now it doesn't momentarily appear to have zero height in between when it loads and when its images load.  

Closes #73.