### PR TITLE
Create toast notification on CMS save success/fail

### DIFF
--- a/public/assets/sass/admin/admin.scss
+++ b/public/assets/sass/admin/admin.scss
@@ -1,4 +1,5 @@
 @import "../mixins/pink-button";
+@import "../mixins/toast-notification";
 
 #navbar {
   background-color: var(--mathsoc-pink);

--- a/public/assets/sass/mixins/_toast-notification.scss
+++ b/public/assets/sass/mixins/_toast-notification.scss
@@ -1,0 +1,44 @@
+.toast {
+  position: fixed;
+  top: 0;
+  z-index: 2;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+
+  transform: translateY(100%);
+  opacity: 0;
+
+  transition: opacity 500ms, transform 500ms;
+
+  &.visible {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  .toast-body {
+    margin: 28px;
+    padding: 20px 24px;
+    border-radius: 4px;
+    width: 20%;
+
+    &.success {
+      background-color: lightgreen;
+    }
+
+    &.fail {
+      background-color: red;
+    }
+
+    .toast-header {
+      font-size: "20px";
+      color: black;
+      font-weight: bold;
+    }
+
+    .toast-message {
+      font-size: "14px";
+      color: black;
+    }
+  }
+}

--- a/public/assets/sass/mixins/_toast-notification.scss
+++ b/public/assets/sass/mixins/_toast-notification.scss
@@ -23,22 +23,24 @@
     width: 20%;
 
     &.success {
-      background-color: lightgreen;
+      background-color: var(--mathsoc-pink-2);
+      color: white;
     }
 
     &.fail {
-      background-color: red;
+      background-color: var(--mathsoc-pink-4);
+      color: black;
     }
 
     .toast-header {
-      font-size: "20px";
-      color: black;
+      font-size: 20px;
       font-weight: bold;
+      font-family: var(--title-font);
     }
 
     .toast-message {
-      font-size: "14px";
-      color: black;
+      font-size: 14px;
+      font-family: var(--primary-font);
     }
   }
 }

--- a/public/assets/ts/admin/editor.ts
+++ b/public/assets/ts/admin/editor.ts
@@ -222,20 +222,35 @@ class Editor {
 
     fetch(link, options).then((response) => {
       const responseCodeClass = Math.floor(response.status / 100) * 100;
+      const errMessage = `Failed to save ${this.name}`;
+      const successMessage = `${this.name} saved successfully!`;
 
       if (responseCodeClass === 200) {
-        location.reload();
+        showToast(successMessage, "success");
       } else {
         switch (response.status) {
           case 400: {
+            showToast(
+              errMessage + `Bad POST request to ${this.sourceDataURL}.`,
+              "fail"
+            );
             throw new Error(`Bad POST request to ${this.sourceDataURL}.`);
           }
           case 401: {
+            showToast(
+              errMessage +
+                `Unauthorized POST request to ${this.sourceDataURL}.`,
+              "fail"
+            );
             throw new Error(
               `Unauthorized POST request to ${this.sourceDataURL}.`
             );
           }
           case 403: {
+            showToast(
+              errMessage + `Forbidden POST request to ${this.sourceDataURL}`,
+              "fail"
+            );
             throw new Error(
               `Forbidden POST request to ${
                 this.sourceDataURL
@@ -243,11 +258,21 @@ class Editor {
             );
           }
           case 404: {
+            showToast(
+              errMessage +
+                `File not found in POST request to ${this.sourceDataURL}.`,
+              "fail"
+            );
             throw new Error(
               `File not found in POST request to ${this.sourceDataURL}.`
             );
           }
           default: {
+            showToast(
+              errMessage +
+                `Unexpected ${response.status} error from GET request to ${this.sourceDataURL}`,
+              "fail"
+            );
             throw new Error(
               `Unexpected ${response.status} error from GET request to ${this.sourceDataURL}`
             );

--- a/public/assets/ts/admin/toast.ts
+++ b/public/assets/ts/admin/toast.ts
@@ -1,0 +1,19 @@
+// the disable will be removed once we can import/export modules in the frontend
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function showToast(message: string, intent: "success" | "fail") {
+  const toast = document.getElementById("toast");
+
+  const toastHeader = document.querySelector(".toast-header");
+  const toastMessage = document.querySelector(".toast-message");
+  const toastBody = document.querySelector(".toast-body");
+
+  toastHeader.innerHTML = intent === "success" ? "Success" : "Failure";
+  toastMessage.innerHTML = message;
+  toast.classList.add("visible");
+  toastBody.classList.add(intent);
+
+  setTimeout(() => {
+    toast.classList.remove("visible");
+  }, 2000);
+}

--- a/public/assets/ts/admin/toast.ts
+++ b/public/assets/ts/admin/toast.ts
@@ -10,6 +10,11 @@ function showToast(message: string, intent: "success" | "fail") {
 
   toastHeader.innerHTML = intent === "success" ? "Success" : "Failure";
   toastMessage.innerHTML = message;
+
+  if (toast.classList.contains("visible")) {
+    return;
+  }
+
   toast.classList.add("visible");
   toastBody.classList.add(intent);
 

--- a/server/data/cartoons/about-us.json
+++ b/server/data/cartoons/about-us.json
@@ -5,7 +5,7 @@
   "coverPicSrcMobile": "/assets/img/cartoons/cartoons-cover-mobile.jpg",
   "comicExample": "/assets/img/cartoons/characters2.jpg",
   "subheading": "About Us",
-  "subheadingCaption": "MathSoc Cartoons is a student-run comic series explaining undergraduate math and computer science concepts. All of our comics can be found here, as well as on our <a href='https://www.instagram.com/uwmathsoc/'>Instagram</a> and <a href='https://www.facebook.com/mathsoc'>Facebook</a> pages.",
+  "subheadingCaptionMarkdown": "MathSoc Cartoons is a student-run comic series explaining undergraduate math and computer science concepts. All of our comics can be found here, as well as on our <a href='https://www.instagram.com/uwmathsoc/'>Instagram</a> and <a href='https://www.facebook.com/mathsoc'>Facebook</a> pages.",
   "joinUs": "Join Us",
   "applicationsCaption": "Applications are now open for Winter 2023!",
   "signupMarkdown": "<ul> <li> Want to join our team? <a href=\"https://docs.google.com/forms/d/e/1FAIpQLSdWl7Op8QZRoG9BZXjB4kl8Xo4BJv8CjQI2-R9Vt6LqIZHTUg/closedform\" target=\"_blank\">Apply to be a writer/artist!</a> </li> <li> Want early access to our new comics? <a href=\"https://docs.google.com/forms/d/e/1FAIpQLScRRe_Cg6n-wJjH1XQ0yFALE_w8hSfCwvjGhi-dRuSXIo_aEA/viewform\" target=\"_blank\">Sign up to be a reviewers!</a> </li> </ul>",

--- a/server/types/schemas.ts
+++ b/server/types/schemas.ts
@@ -102,7 +102,7 @@ const CartoonsAboutUsDataSchema = z.object({
   coverPicSrcMobile: z.string(),
   comicExample: z.string(),
   subheading: z.string(),
-  subheadingCaption: z.string(),
+  subheadingCaptionMarkdown: z.string(),
   joinUs: z.string(),
   applicationsCaption: z.string(),
   signupMarkdown: z.string(),

--- a/views/mixins/components.pug
+++ b/views/mixins/components.pug
@@ -5,3 +5,4 @@ include ./flip-card.pug
 include ./person-card.pug
 include ./pink-button.pug
 include ./instagram-embed.pug
+include ./toast-notification.pug

--- a/views/mixins/toast-notification.pug
+++ b/views/mixins/toast-notification.pug
@@ -1,0 +1,5 @@
+mixin toast()
+    div(class="toast" id="toast")
+        div(class="toast-body")
+            div(class="toast-header")
+            div(class="toast-message")

--- a/views/templates/admin-base.pug
+++ b/views/templates/admin-base.pug
@@ -8,9 +8,11 @@ html(lang="en")
   link(href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet")
   script(src="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.9.2/jsoneditor.min.js" integrity="sha512-MP2pEPP3BGw032ovuAsX6yTu7O4J6L3YTXuyq3IpR+LuwRun9BBjOeeIKgO3bRiNlI88x3oCVb9I1/1+xmvFIg==" crossorigin="anonymous" referrerpolicy="no-referrer")
   script(src="https://cdn.quilljs.com/1.3.6/quill.js")
+  script(src="/assets/js/admin/toast.js")
   
   body 
     include /views/partials/navbar.pug
+    +toast()
     h1(id="admin-title") MathSoc Admin
     div(id="sections-menu")
       ul


### PR DESCRIPTION
Closes #56 

This pr creates a new mixin (toast-notification), and this toast is currently shown after each save action in the CMS. If the save was successful, the toast has a 'success' intent. If the save was unsuccessful, the toast has a 'fail' intent