### PR TITLE
Add empty ADFS redirect route

### DIFF
--- a/public/assets/sass/main.scss
+++ b/public/assets/sass/main.scss
@@ -72,3 +72,6 @@ section:last-child {
   padding-bottom: 30px;
 }
 
+#body {
+  position: relative;
+}

--- a/server/config/pages.json
+++ b/server/config/pages.json
@@ -84,5 +84,10 @@
     "title": "Page Not Found",
     "ref": "/error",
     "view": "/error"
+  },
+  {
+    "title": "Authentication Redirect",
+    "ref": "/auth-redirect",
+    "view": "/auth-redirect"
   }
 ]

--- a/server/data/contact-us.json
+++ b/server/data/contact-us.json
@@ -20,7 +20,7 @@
     {
       "name": "Math Coffee and Donut",
       "room": "MC 3002",
-      "img": "/assets/img/portrait-images/cnd.JPG"
+      "img": "/assets/img/portrait-images/cnd.jpg"
     },
     {
       "name": "MC Comfy",

--- a/views/pages/auth-redirect.pug
+++ b/views/pages/auth-redirect.pug
@@ -1,0 +1,19 @@
+extends /views/templates/frontend-base.pug
+
+block body 
+  img(src="assets/img/banners/pinktie-mc.jpeg" style="width: 100%; max-height: 700px")
+  div(style="position: absolute;top: 50%;left: 50%;background: #fff;transform: translate(-50%, -50%);padding: 2em;")
+    h3 This route will handle redirection after ADFS authentication.
+    p 
+      .
+        We intend to pass in the user's intended route as a state value mapped to an href.  This 
+        was the method employed by the 2019 MathSoc website, which is currently registered with ADFS, at 
+        services.mathsoc.uwaterloo.ca.
+
+    p
+      .
+        In our implementation, if a user is redirected to ADFS before accessing the exam bank, the state would reflect that.
+        Then, this route would be able to interpret the state and send the user to #[code /resources/exam-bank].
+
+    p We'll have a smoother time developing the redirection functionality once this staging site is registered with ADFS. 
+    p Thanks for the help!


### PR DESCRIPTION
he's just like the mathsoc website fr
![](https://media.tenor.com/ubM_a40bzbAAAAAM/jedi-master-yoda.gif)

Adds a new route at `/auth-redirect`, which I'll ask Waterloo IT to add as a redirect route within Microsoft Azure.  This sets us up to use a similar implementation of ADFS authentication as was used by the 2019 [services.mathsoc.uwaterloo.ca](https://services.mathsoc.uwaterloo.ca/university/exambank) site.

Also fixes a small issue with a broken image on the contact us page.