### PR TITLE
Add visual cue to generic page editor

### DIFF
--- a/public/assets/sass/admin/admin.scss
+++ b/public/assets/sass/admin/admin.scss
@@ -135,7 +135,7 @@ body {
   width: 100%;
   text-align: center;
 
-  .open-editor-button {
+  #open-editor-btn {
     appearance: initial;
     display: block;
     margin: 1em auto;

--- a/public/assets/sass/admin/generic-editor.scss
+++ b/public/assets/sass/admin/generic-editor.scss
@@ -61,6 +61,14 @@
   }
 }
 
+.jsoneditor .jsoneditor-value.jsoneditor-string {
+  &.highlighted-markdown-field,
+  &.hoverable-markdown-field:hover {
+    background: #df249829;
+    border: 1px dashed var(--mathsoc-pink);
+  }
+}
+
 .editor-name {
   font-weight: bold;
 }

--- a/server/routes/admin-routes.ts
+++ b/server/routes/admin-routes.ts
@@ -16,20 +16,20 @@ interface EditorPageOutflow extends PageOutflow {
 }
 
 class AuthRoutesConstructor {
-  static buildRoutes() {
+  static async buildRoutes() {
     PageLoader.buildRoutes(
       adminPages,
       router,
       this.addAdminSpecificOutflowToPage
     );
-    this.generateEditorPage();
+    await this.generateEditorPage();
   }
 
   /**
    * Handles the custom data input necessary for the editor pages.
    */
-  static generateEditorPage() {
-    const genericEditorPageOutflow = PageLoader.getAllPageData(
+  static async generateEditorPage() {
+    const genericEditorPageOutflow = await PageLoader.getAllPageData(
       {
         title: "Editor",
         ref: "/admin/editor",

--- a/server/routes/controllers/page-loader.ts
+++ b/server/routes/controllers/page-loader.ts
@@ -81,7 +81,6 @@ export class PageLoader {
     const url = `server/data${pageRef}`;
     if (fs.existsSync(`${url}.json`)) {
       const result = new Promise((resolve) => {
-        console.log(`getting ${url}`);
         ReadWriteController.getJSONDataPath(pageRef, (statusCode, body) =>
           resolve(body)
         );

--- a/views/pages/admin/generic-editor.pug
+++ b/views/pages/admin/generic-editor.pug
@@ -32,7 +32,7 @@ block body
       h2(id="editor-title")=editorName
       div(id="jsoneditor" data-source=editorSource)
       div(class="open-editor-container")
-        button(class="pink-button disabled open-editor-button" id="open-editor-btn" disabled="true") Open Markdown Editor
+        button(class="pink-button disabled" id="open-editor-btn" disabled="true") Open Markdown Editor
       div(class="save-button-container")
         button(class="save pink-button" id="save-editor-btn") Save 
           span(class="editor-name")


### PR DESCRIPTION
![](https://media.tenor.com/lnbK373D2AkAAAAM/kot-koty.gif)

This adds a hover/clicked state to the `.*Markdown` editor fields, allowing the user to better understand what they're currently doing while using the page editor.

![image](https://user-images.githubusercontent.com/37753525/229401956-818427d8-59dc-4c61-bb15-827f0b5d78d6.png)

Also fixes an error that had broken routing to the editors.