### PR TITLE
Fix ADFS login loop

### DIFF
--- a/docker-reset
+++ b/docker-reset
@@ -1,0 +1,9 @@
+#/bin/bash!
+
+# this is a helpful file to kill the current docker process,
+#  then pull any changes and start up docker again
+
+docker kill $(docker ps -q)
+git pull
+npm run dockerize
+docker logs $(docker ps -q)

--- a/server/auth/adfs.ts
+++ b/server/auth/adfs.ts
@@ -45,7 +45,6 @@ const regenerateSessionAfterAuthentication = (
   next: NextFunction
 ) => {
   const passportInstance = req.session.passport;
-  console.log("Passport has regenerated session");
   return req.session.regenerate(function (err) {
     if (err) {
       return next(err);
@@ -60,8 +59,6 @@ export const adfsMiddleware = (
   res: Response,
   next: NextFunction
 ) => {
-  console.log("adfs middleware called");
-  console.log(req);
   if (req.user) {
     next();
   } else {
@@ -88,7 +85,7 @@ router.get(
 );
 
 router.post(
-  "/authorize/callback",
+  "/auth-redirect",
   passport.authenticate("azuread-openidconnect", {
     failureRedirect: tokens.POST_LOGOUT_REDIRECT_URI ?? "",
     prompt: "login",

--- a/server/auth/adfs.ts
+++ b/server/auth/adfs.ts
@@ -45,6 +45,7 @@ const regenerateSessionAfterAuthentication = (
   next: NextFunction
 ) => {
   const passportInstance = req.session.passport;
+  console.log("Passport has regenerated session");
   return req.session.regenerate(function (err) {
     if (err) {
       return next(err);
@@ -59,6 +60,8 @@ export const adfsMiddleware = (
   res: Response,
   next: NextFunction
 ) => {
+  console.log("adfs middleware called");
+  console.log(req);
   if (req.user) {
     next();
   } else {

--- a/views/pages/auth-redirect.pug
+++ b/views/pages/auth-redirect.pug
@@ -3,17 +3,9 @@ extends /views/templates/frontend-base.pug
 block body 
   img(src="assets/img/banners/pinktie-mc.jpeg" style="width: 100%; max-height: 700px")
   div(style="position: absolute;top: 50%;left: 50%;background: #fff;transform: translate(-50%, -50%);padding: 2em;")
-    h3 This route will handle redirection after ADFS authentication.
+    h3 Hi!
+    p You've been logged in!
+    p We should use the state query param to redirect from this page.
     p 
-      .
-        We intend to pass in the user's intended route as a state value mapped to an href.  This 
-        was the method employed by the 2019 MathSoc website, which is currently registered with ADFS, at 
-        services.mathsoc.uwaterloo.ca.
-
-    p
-      .
-        In our implementation, if a user is redirected to ADFS before accessing the exam bank, the state would reflect that.
-        Then, this route would be able to interpret the state and send the user to #[code /resources/exam-bank].
-
-    p We'll have a smoother time developing the redirection functionality once this staging site is registered with ADFS. 
-    p Thanks for the help!
+    | For now, the fact that you see this instead of an infinite login loop 
+    | is success enough :) 


### PR DESCRIPTION
Resolves the login loop issue we were having by ensuring that `POST /auth-redirect`, which was being sent by ADFS, had a working endpoint to reach.