### PR TITLE
Remove auth from development flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,18 @@
 forms_gmail_sender_username=website@mathsoc.uwaterloo.ca
 forms_gmail_sender_password=password123
-WATERLOO_OPEN_API_KEY="PUT_API_KEY_HERE"
-WATERLOO_OPEN_API_BASE_URL="https://openapi.data.uwaterloo.ca/v3"
+WATERLOO_OPEN_API_KEY=PUT_API_KEY_HERE
+WATERLOO_OPEN_API_BASE_URL=https://openapi.data.uwaterloo.ca/v3
 PORT=8000
 
-ADFS_SERVER="https://adfs.uwaterloo.ca/" # cloud instance string should end with a trailing slash
-TENANT_ID="uwaterloo.ca"
-ADFS_CLIENT_ID="put_client_id_here"
+ADFS_SERVER=https://adfs.uwaterloo.ca/ # cloud instance string should end with a trailing slash
+TENANT_ID=uwaterloo.ca
+ADFS_CLIENT_ID=put_client_id_here
 
-REDIRECT_URI="https://staging9000.mathsoc.uwaterloo.ca/auth-redirect"
-POST_LOGOUT_REDIRECT_URI="https://staging9000.mathsoc.uwaterloo.ca/"
+REDIRECT_URI=https://staging9000.mathsoc.uwaterloo.ca/auth-redirect
+POST_LOGOUT_REDIRECT_URI=https://staging9000.mathsoc.uwaterloo.ca/
 
-EXPRESS_SESSION_SECRET="put_session_secret_here"
-COOKIE_ENCRYPTION_KEY="put_cookie_encryption_key_here"
-COOKIE_ENCRYPTION_IV="put_cookie_encryption_iv_here"
-HOST_NAME="https://staging9000.mathsoc.uwaterloo.ca/"
+EXPRESS_SESSION_SECRET=put_session_secret_here
+COOKIE_ENCRYPTION_KEY=put_cookie_encryption_key_here
+COOKIE_ENCRYPTION_IV=put_cookie_encryption_iv_here
+HOST_NAME=https://staging9000.mathsoc.uwaterloo.ca/
+IS_PRODUCTION=false

--- a/config.ts
+++ b/config.ts
@@ -10,12 +10,13 @@ const tokens = {
   COOKIE_ENCRYPTION_KEY: process.env.COOKIE_ENCRYPTION_KEY ?? null,
   COOKIE_ENCRYPTION_IV: process.env.COOKIE_ENCRYPTION_IV ?? null,
   POST_LOGOUT_REDIRECT_URI: process.env.POST_LOGOUT_REDIRECT_URI ?? null,
+  IS_PRODUCTION: process.env.IS_PRODUCTION ?? null,
 };
 
 const missingTokens: string[] = [];
 
 for (const [key, value] of Object.entries(tokens)) {
-  if (!value) {
+  if (value === null) {
     missingTokens.push(key);
   }
 }

--- a/server/auth/adfs.ts
+++ b/server/auth/adfs.ts
@@ -59,6 +59,11 @@ export const adfsMiddleware = (
   res: Response,
   next: NextFunction
 ) => {
+  if (tokens.IS_PRODUCTION !== "true") {
+    next();
+    return;
+  }
+
   if (req.user) {
     next();
   } else {


### PR DESCRIPTION
Allows the admin backend and development flow to be accessed while in development, but not in production.

If `IS_PRODUCTION` is unset, the server crashes.  There shouldn't be a situation where it accidentally is set wrong.

Additionally:
* Removes quotation marks from `.env.example` to match values used in Docker