### PR TITLE
Ensure MathSoc logins match allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ts-watch": "webpack --config webpack.config.js --watch",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "husky install",
-    "dockerize": "sudo docker build . -t mathsoc-website && docker run --env-file ./.env -p 9000:9000 -d mathsoc-website"
+    "dockerize": "docker build . -t mathsoc-website && docker run --env-file ./.env -p 9000:9000 -d mathsoc-website"
   },
   "repository": {
     "type": "git",

--- a/server/auth/google.ts
+++ b/server/auth/google.ts
@@ -42,7 +42,7 @@ if (tokens.IS_DEVELOPMENT !== "true") {
 
         return done(
           new Error(
-            `MathSoc profile ${profile.username} is not authorized with admin permissions`
+            `MathSoc profile ${profile.displayName} is not authorized with admin permissions`
           )
         );
       }

--- a/server/auth/google.ts
+++ b/server/auth/google.ts
@@ -32,9 +32,11 @@ if (tokens.IS_DEVELOPMENT !== "true") {
           return done(new Error("No username found"));
         }
 
-        for (const email in profile.emails) {
-          if (PermissionsHandler.shouldHaveAdminRights(email)) {
-            return done(null, { username, adminAccess: true });
+        if (profile.emails) {
+          for (const email of profile.emails) {
+            if (PermissionsHandler.shouldHaveAdminRights(email.value)) {
+              return done(null, { username, adminAccess: true });
+            }
           }
         }
 

--- a/server/auth/permissions.ts
+++ b/server/auth/permissions.ts
@@ -1,5 +1,9 @@
 import permissionsConfig from "../config/admin/user-perms.json";
 
+/**
+ * Permissions are managed in-code in the config/admin/user-perms.json
+ */
+
 export class PermissionsHandler {
   static shouldHaveAdminRights(email: string): boolean {
     return permissionsConfig.admin.includes(email);

--- a/server/auth/permissions.ts
+++ b/server/auth/permissions.ts
@@ -1,0 +1,7 @@
+import permissionsConfig from "../config/admin/user-perms.json";
+
+export class PermissionsHandler {
+  static shouldHaveAdminRights(email: string): boolean {
+    return permissionsConfig.admin.includes(email);
+  }
+}

--- a/server/config/admin/user-perms.json
+++ b/server/config/admin/user-perms.json
@@ -1,0 +1,11 @@
+{
+  "admin": [
+    "president@mathsoc.uwaterloo.ca",
+    "vpa@mathsoc.uwaterloo.ca",
+    "vpf@mathsoc.uwaterloo.ca",
+    "vpi@mathsoc.uwaterloo.ca",
+    "vpc@mathsoc.uwaterloo.ca",
+    "vpo@mathsoc.uwaterloo.ca",
+    "webdev@mathsoc.uwaterloo.ca"
+  ]
+}


### PR DESCRIPTION
**The Problem:**

Anyone from MathSoc was previously able to log in, so long as they had a valid @mathsoc.uwaterloo.ca address.  They all had full rights to do anything.

Admittedly I don't know how many @mathsoc.uwaterloo.ca emails exist but this felt like an issue.

**The Solution:**

Add an allowlist.
