### PR TITLE
Hide elections page behind student auth

### DIFF
--- a/server/config/authenticated-pages.json
+++ b/server/config/authenticated-pages.json
@@ -3,5 +3,10 @@
     "title": "Exam Bank",
     "ref": "/resources/exam-bank",
     "view": "/resources/exam-bank"
+  },
+  {
+    "title": "Elections",
+    "ref": "/elections",
+    "view": "/elections/elections"
   }
 ]

--- a/server/config/pages.json
+++ b/server/config/pages.json
@@ -54,11 +54,6 @@
     ]
   },
   {
-    "title": "Elections",
-    "ref": "/elections",
-    "view": "/elections/elections"
-  },
-  {
     "title": "Resources",
     "children": [
       {


### PR DESCRIPTION
For privacy reasons, hides elections information behind ADFS authentication.