### PR TITLE
Re-enable node deletion

### DIFF
--- a/public/assets/ts/admin/editor.ts
+++ b/public/assets/ts/admin/editor.ts
@@ -196,19 +196,18 @@ export class Editor {
   }
 
   /*
-  - stops users from modifying field and value for markdown fields
-  - stops users from modifying field names for the rest of the fields
+  - stops users from modifying value directly for markdown fields
   */
   private onEditorEditable(node: { field?: string }) {
     if (node && node.field && node.field.includes("Markdown")) {
       return {
-        field: false,
+        field: true,
         value: false
       };
     }
 
     return {
-      field: false,
+      field: true,
       value: true
     };
   }


### PR DESCRIPTION
In the current state, we can't delete nodes in the JSON editor. This fixes that issue.