### PR TITLE
Enable schema checking in page editors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "webpack": "^5.82.0",
         "webpack-cli": "^5.1.0",
         "winston": "^3.8.2",
-        "zod": "^3.20.2"
+        "zod": "^3.20.2",
+        "zod-to-json-schema": "^3.21.4"
       },
       "devDependencies": {
         "@swc/core": "^1.3.32",
@@ -8795,6 +8796,14 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.21.4.tgz",
+      "integrity": "sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==",
+      "peerDependencies": {
+        "zod": "^3.21.4"
+      }
     }
   },
   "dependencies": {
@@ -15207,6 +15216,12 @@
       "version": "3.21.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
+    },
+    "zod-to-json-schema": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.21.4.tgz",
+      "integrity": "sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "webpack": "^5.82.0",
     "webpack-cli": "^5.1.0",
     "winston": "^3.8.2",
-    "zod": "^3.20.2"
+    "zod": "^3.20.2",
+    "zod-to-json-schema": "^3.21.4"
   },
   "devDependencies": {
     "@swc/core": "^1.3.32",

--- a/public/assets/ts/admin/editor.ts
+++ b/public/assets/ts/admin/editor.ts
@@ -1,5 +1,7 @@
 import { showToast } from "./toast";
 import Quill from "quill";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { mapping } from "../../../../server/validation/endpoint-schema-map";
 import JSONEditor, { JSONEditorOptions } from "jsoneditor";
 
 enum MarkdownFieldHighlightClasses {
@@ -29,12 +31,21 @@ export class Editor {
     this.richTextEditor = new Quill("#quill-editor", {
       theme: "snow"
     });
+
+    const path = new URLSearchParams(sourceDataURL.split("?")[1]).get("path");
+    const schema = mapping[path];
+
+    if (!schema) {
+      console.warn(`No schema found for ${path}`);
+    }
+
     this.options = {
-      onEditable: this.onEditorEditable,
-      onEvent: this.onEditorEvent.bind(this),
       enableSort: false,
       enableTransform: false,
-      navigationBar: false
+      onEditable: this.onEditorEditable,
+      onEvent: this.onEditorEvent.bind(this),
+      navigationBar: false,
+      schema: zodToJsonSchema(schema)
     };
 
     this.sourceDataURL = sourceDataURL;


### PR DESCRIPTION
Enables schema checking in page editors.

![image](https://github.com/MathSoc/mathsoc-website/assets/37753525/08ec3a6f-6984-4105-92f9-9ece3cca1d4a)

How to test: Try adding a field that does not exist in an existing page editor. It will show warnings!