### PR TITLE
Fix initial editor

### DIFF
--- a/server/routes/admin-routes.ts
+++ b/server/routes/admin-routes.ts
@@ -31,7 +31,7 @@ class AdminRoutesConstructor {
     );
 
     router.get("/admin/editor", async (req: Request, res: Response) => {
-      const file = req.query["page"] ?? "home";
+      const file = req.query["page"] ?? "contact-us";
       const filename: string =
         typeof file === "string" ? file : file.toString();
 


### PR DESCRIPTION
At the moment, opening the page editor without any page selected tries to open the homepage editor.

We deleted this page editor. Trying to open the homepage editor just gets a blank screen. 💀 

This updates the default to an editor that still exists.