### PR TITLE
Allow image selection in the page editors

### DIFF
--- a/public/assets/sass/admin/generic-editor.scss
+++ b/public/assets/sass/admin/generic-editor.scss
@@ -59,6 +59,83 @@
     padding: $padding;
     width: calc(100% - 2 * $padding);
   }
+
+  .editor-image-node-inner {
+    img {
+      max-height: 150px;
+      max-width: 150px;
+      cursor: pointer;
+    }
+
+    .editor-image-node-buttons {
+      display: flex;
+      flex-direction: row;
+      gap: 12px;
+      font-size: 12px;
+
+      button {
+        cursor: pointer;
+        
+        &:focus-visible {
+          outline: auto;
+        }
+
+        &:hover {
+          background-color: var(--background-hover);
+        }
+      }
+      
+      .image-node-item {
+        flex: 1;
+        display: block;
+
+        background-color: var(--background-colour-3);
+      }
+    }
+
+
+    .hidden-file-uploader {
+      display: none;
+    }
+  }
+
+  #editor-image-upload-modal-bg {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #8888;
+
+    #editor-image-upload-modal-container {
+      position: absolute;
+      top: 40px;
+      left: 50%;
+      translate: -50% 0;
+      width: 80%;
+      background-color: var(--background-colour);
+      border: 2px solid var(--mathsoc-pink);
+      padding: 16px;
+
+      #image-list {
+        display: flex;
+        gap: 20px;
+        flex-direction: row;
+        flex-wrap: wrap;
+
+        .image-button {
+          max-width: 250px;
+          max-height: 250px;
+          cursor: pointer;
+
+          img {
+            max-width: 100%;
+            max-height: 100%;
+          }
+        }
+      }
+    }
+  }
 }
 
 .editor-name {

--- a/public/assets/ts/admin/image-store.ts
+++ b/public/assets/ts/admin/image-store.ts
@@ -1,3 +1,4 @@
+import { ImageUploader } from "./image-uploader";
 import { showToast } from "./toast";
 
 // @todo use a single source of the Image type for frontend and backend
@@ -35,6 +36,16 @@ class ImageStoreFrontend {
     return images;
   }
 
+  private static async uploadImages() {
+    const fileInput = document.getElementsByName(
+      "images"
+    )[0] as HTMLInputElement;
+    const files = fileInput.files;
+
+    await ImageUploader.uploadImages(files);
+    await ImageStoreFrontend.populateImages();
+  }
+
   private static createImageCard(img: Image): HTMLElement {
     const hiddenImage = this.getImageContainer().querySelector("#hidden-image");
     const newImageCard = hiddenImage.cloneNode(true) as HTMLElement;
@@ -59,41 +70,6 @@ class ImageStoreFrontend {
     newImageCard.querySelector(".img-name").innerHTML = img.fileName;
 
     return newImageCard;
-  }
-
-  private static async uploadImages() {
-    const fileInput = document.getElementsByName(
-      "images"
-    )[0] as HTMLInputElement;
-    const files = fileInput.files;
-
-    if (!files.length) {
-      showToast(
-        "No files were uploaded. Please try again after uploading a file.",
-        "fail"
-      );
-      return;
-    }
-
-    const formData = new FormData();
-
-    for (let file = 0; file < files.length; file++) {
-      formData.append("images", files.item(file));
-    }
-
-    const options = {
-      method: "POST",
-      body: formData,
-    };
-
-    const response = await fetch("/api/image/upload", options);
-    const parsedResponse = await response.json();
-    await ImageStoreFrontend.populateImages();
-    if (parsedResponse.errors.length) {
-      showToast(parsedResponse.errors.join(", "), "fail");
-    }
-
-    return;
   }
 
   private static resetImageContainer() {

--- a/public/assets/ts/admin/image-uploader.ts
+++ b/public/assets/ts/admin/image-uploader.ts
@@ -1,0 +1,32 @@
+import { showToast } from "./toast";
+
+export class ImageUploader {
+  static async uploadImages(files: FileList) {
+    if (!files.length) {
+      showToast(
+        "No files were uploaded. Please try again after uploading a file.",
+        "fail"
+      );
+      return;
+    }
+
+    const formData = new FormData();
+
+    for (let file = 0; file < files.length; file++) {
+      formData.append("images", files.item(file));
+    }
+
+    const options = {
+      method: "POST",
+      body: formData,
+    };
+
+    const response = await fetch("/api/image/upload", options);
+    const parsedResponse = await response.json();
+    if (parsedResponse.errors.length) {
+      showToast(parsedResponse.errors.join(", "), "fail");
+    }
+
+    return parsedResponse.files;
+  }
+}

--- a/public/assets/ts/admin/page-editor/editor-nodes/EditorImageNode.tsx
+++ b/public/assets/ts/admin/page-editor/editor-nodes/EditorImageNode.tsx
@@ -1,0 +1,121 @@
+import React, { useContext, useEffect, useRef, useState } from "react";
+import { EditorNodeProps, EditorNodeTemplate } from "./EditorNodeTemplate";
+import { EditorContext } from "../EditorV2";
+import { ImageUploader } from "../../image-uploader";
+
+// @todo use a single source for this type, at least across the frontend
+type Image = {
+  fileName: string;
+  path: string;
+  publicLink: string;
+  fileType: string;
+};
+
+export const EditorImageNode: React.FC<EditorNodeProps> = (props) => {
+  const { path } = props;
+  const { getDataValue, setDataValue } = useContext(EditorContext);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const imageSource = getDataValue(path);
+
+  const imageUploadInputRef = useRef<HTMLInputElement>(null);
+
+  const openUpload = () => {
+    imageUploadInputRef.current?.click();
+  };
+
+  const selectImage = (imageName: string) => {
+    setDataValue(path, imageName);
+  };
+
+  const handleFileSelect = async () => {
+    const file = imageUploadInputRef.current?.files;
+    if (!file) {
+      return;
+    }
+
+    const fileName = (await ImageUploader.uploadImages(file))[0];
+    selectImage(`/assets/img/uploads/${fileName}`);
+  };
+
+  const clearImage = () => {
+    setDataValue(path, "");
+  };
+
+  return (
+    <EditorNodeTemplate key={path.join("-")} {...props}>
+      <div className="editor-image-node-inner">
+        <div className="editor-image-node-buttons">
+          <img className="image-node-item" src={imageSource} />
+          <button
+            className="image-node-item"
+            onClick={() => setIsModalOpen(!isModalOpen)}
+          >
+            Select new image
+          </button>
+          <button className="image-node-item" onClick={openUpload}>
+            Upload new image
+          </button>
+          <button className="image-node-item" onClick={clearImage}>
+            Deselect image
+          </button>
+        </div>
+        <input
+          type="file"
+          className="hidden-file-uploader"
+          ref={imageUploadInputRef}
+          onChange={handleFileSelect}
+          accept="image/*"
+        />
+      </div>
+      {isModalOpen ? (
+        <UploadImageModal
+          selectImage={selectImage}
+          closeModal={() => setIsModalOpen(false)}
+        />
+      ) : null}
+    </EditorNodeTemplate>
+  );
+};
+
+const UploadImageModal: React.FC<{
+  selectImage: (imageLink: string) => void;
+  closeModal: () => void;
+}> = ({ selectImage, closeModal }) => {
+  const [images, setImages] = useState<Image[]>([]);
+
+  useEffect(() => {
+    fetch("/api/images")
+      .then((res) => res.json())
+      .then((imageList: Image[]) => {
+        setImages(imageList);
+      });
+  }, []);
+
+  const onSelect = (imageLink: string) => {
+    selectImage(imageLink);
+    closeModal();
+  };
+
+  return (
+    <div id="editor-image-upload-modal-bg" onClick={closeModal}>
+      <div
+        id="editor-image-upload-modal-container"
+        onClick={(e) => e.stopPropagation()} // don't close every time the modal is clicked
+      >
+        <h2>Select an image</h2>
+        <div id="image-list">
+          {images.map((image) => (
+            <button
+              className="image-button"
+              key={image.publicLink}
+              onClick={() => onSelect(image.publicLink)}
+            >
+              <img src={image.publicLink} />
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/public/assets/ts/admin/page-editor/editor-nodes/EditorNode.tsx
+++ b/public/assets/ts/admin/page-editor/editor-nodes/EditorNode.tsx
@@ -5,6 +5,7 @@ import { EditorLabelNode } from "./EditorLabelNode";
 import { EditorArrayNode } from "./EditorArrayNode";
 import { EditorNodeProps } from "./EditorNodeTemplate";
 import { EditorContext } from "../EditorV2";
+import { EditorImageNode } from "./EditorImageNode";
 
 export const EditorNode: React.FC<EditorNodeProps & { value: any }> = (
   props
@@ -19,6 +20,8 @@ export const EditorNode: React.FC<EditorNodeProps & { value: any }> = (
     } else {
       return <EditorObjectNode {...props} />;
     }
+  } else if (props.name.toLowerCase().includes("image")) {
+    return <EditorImageNode {...props} />;
   } else if (props.name.includes("Markdown")) {
     return <EditorMarkdownNode {...props} />;
   } else {

--- a/public/assets/ts/admin/page-editor/usePageSources.ts
+++ b/public/assets/ts/admin/page-editor/usePageSources.ts
@@ -10,5 +10,8 @@ export const usePageSources = (source: string) => {
       const result = await res.json();
       return result;
     },
+    // this prevents image edits from being reset
+    //   every time you leave the window.
+    refetchOnWindowFocus: false,
   });
 };

--- a/server/api/controllers/image-controller.ts
+++ b/server/api/controllers/image-controller.ts
@@ -133,7 +133,11 @@ export class ImageController extends AbstractFileController<
 
     const urlSearchParams = new URLSearchParams();
     errors.forEach((item) => urlSearchParams.append("errors", item));
-    res.send({ status: "success", errors: errors });
+    res.status(201).send({
+      status: "success",
+      errors: errors,
+      files: images.map((im) => im.fileName),
+    });
   }
 
   processFileDelete(request: ImageDeleteRequest): void {


### PR DESCRIPTION
At the moment, we only allow image selection by entering the source link into a text field in the CMS. That is, something like manually setting an exec's profile image url to `/assets/img/uploads/amazing-linkedin-bridge-headshot.png`. 

This simplifies that flow for less technical users, by instead replacing url fields with a clear set of buttons allowing them to update a selected image.

**Old image selection:**

![image](https://github.com/MathSoc/mathsoc-website/assets/37753525/e94a7958-260b-4add-920b-566d1601ddde)

**New image selection node:**

![image](https://github.com/MathSoc/mathsoc-website/assets/37753525/7b9bbbcd-48c8-46c1-8235-a4fa7445131d)


**Select modal:**

![image](https://github.com/MathSoc/mathsoc-website/assets/37753525/5d204ed6-2d35-4176-aa5d-0c4d34087b3a)

**Next steps:**

We can use a very similar selector for documents.
