### PR TITLE
Editor: Clear array subelements in new elements

### DIFF
--- a/public/assets/ts/admin/page-editor/editor-nodes/EditorArrayNode.tsx
+++ b/public/assets/ts/admin/page-editor/editor-nodes/EditorArrayNode.tsx
@@ -28,11 +28,24 @@ export const EditorArrayNode: React.FC<EditorNodeProps> = (props) => {
     setVersion(version + 1);
   };
 
+  // Deletes all elements of any array anywhere in an object(?) v
+  const clearArrays = (v: any) => {
+    if (Array.isArray(v)) {
+      return [];
+    } else if (typeof v == "object") {
+      for (const key in v) {
+        v[key] = clearArrays(v[key]);
+      }
+    }
+
+    return v;
+  };
+
   const addItem = () => {
     const newItemPath = path.concat(transformedData.length.toString());
     const newItemSchema = getSchemaValue(path)[0];
 
-    setDataValue(newItemPath, newItemSchema);
+    setDataValue(newItemPath, clearArrays(newItemSchema));
   };
 
   return (


### PR DESCRIPTION
See the images below. This feels like a far more intuitive experience to not have subarrays autopopulate, which they currently do.

**Old experience after pressing "New" in the array editor**

(the candidates subarray has automatically been populated with an element)

![image](https://github.com/MathSoc/mathsoc-website/assets/37753525/de0daeb9-81bc-4953-b0d1-84e0108ce319)

**Newexperience after pressing "New" in the array editor**

(the candidates subarray is empty)

![image](https://github.com/MathSoc/mathsoc-website/assets/37753525/57ccaac5-f5fb-4ed3-ad3e-c934def3a754)
