### PR TITLE
Fix server startup issues

### DIFF
--- a/backup.ts
+++ b/backup.ts
@@ -11,6 +11,7 @@ const createDirectory = (directory: string) => {
   const exists = fs.existsSync(directory);
   if (!exists) {
     try {
+      console.info(`Making backup directory: ${directory}`);
       fs.mkdirSync(directory);
     } catch (err) {
       console.error(
@@ -29,6 +30,7 @@ const numBackups = (directory: string): number => {
 
 const deleteOldestBackup = (directory: string): void => {
   try {
+    console.info(`Finding oldest backup...`);
     const directories = fs
       .readdirSync(directory, { withFileTypes: true })
       .filter((dir) => dir.isDirectory())
@@ -43,10 +45,12 @@ const deleteOldestBackup = (directory: string): void => {
 
     const oldestDirectoryName = directories[0].name;
 
+    console.info(`Deleting the oldest backup: ${oldestDirectoryName}`);
+
     fs.rmSync(path.join(directory, oldestDirectoryName), {
       recursive: true,
     });
-    console.log("Oldest backup deleted: " + oldestDirectoryName);
+    console.info("Oldest backup deleted: " + oldestDirectoryName);
   } catch (err) {
     console.error("Unable to delete oldest backup with error: " + err);
   }
@@ -69,11 +73,11 @@ const runJobs = () => {
         }
 
         if (code == 0) {
-          console.log("Backup completed successfully: " + newDate);
+          console.info("Backup completed successfully: " + newDate);
           const numberOfBackups = numBackups(directoryName);
           if (numberOfBackups == 7) deleteOldestBackup(directoryName);
         } else {
-          console.log("Backup failed with code " + code);
+          console.error("Backup failed with code " + code);
         }
       });
     },
@@ -86,4 +90,7 @@ const runJobs = () => {
   job.start();
 };
 
+console.log("Initializing backup job...");
 runJobs();
+console.log("Backup job initialized!");
+process.exit();

--- a/backup.ts
+++ b/backup.ts
@@ -90,7 +90,7 @@ const runJobs = () => {
   job.start();
 };
 
-console.log("Initializing backup job...");
+console.info("Initializing backup job...");
 runJobs();
-console.log("Backup job initialized!");
+console.info("Backup job initialized!");
 process.exit();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ts-watch": "webpack --config webpack.config.js --watch",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "husky install",
-    "dockerize": "docker build . -t mathsoc-website && docker run --env-file ./.env -p 9000:9000 -d mathsoc-website"
+    "dockerize": "docker build . -t mathsoc-website && docker run --env-file ./.env -p 9000:9000 mathsoc-website"
   },
   "repository": {
     "type": "git",

--- a/preload.ts
+++ b/preload.ts
@@ -1,5 +1,8 @@
 import { DataFiller } from "./preload/data-filler";
 import { DirectoryPrebuilder } from "./preload/directory-prebuilder";
 
-DirectoryPrebuilder.prebuild();
-DataFiller.fillDataFolder();
+(async () => {
+  await DirectoryPrebuilder.prebuild();
+  await DataFiller.fillDataFolder();
+  process.exit();
+})();

--- a/server.ts
+++ b/server.ts
@@ -20,6 +20,8 @@ import passport from "passport";
 import session from "express-session";
 import { setUpPassport } from "./server/auth/auth";
 
+console.info("Starting server...");
+
 const logger = new Logger();
 
 const app = express();


### PR DESCRIPTION
The staging server is having a moment. 

* **Problem one: Restart loops**
  * Despite the staging server appearing to start up healthily, it was immediately killing the startup process and restarting every time it had successfully built the image.
  * I found that when I removed the `-d` flag, this restart loop stopped. `-d` made the normal node terminal run in the background, which I think was telling the service "This process is done now :) feel free to restart yourself in 10 seconds from now :)))"
* **Problem two: `/server/data` race condition**
  * Once I'd fixed that issue, I started getting errors along the lines of of "`scandir` failed to run on `/server/data`; directory does not exist"
  * I traced that down to a race condition on `preload.ts`, where the `DirectoryPrebuilder.prebuild();` wasn't building the `/server/data` folder before `DataFiller.fillDataFolder();` needed it. Adding `await` solved the problem.
* **Problem three: freezing?**
  * I was still finding that the `npm run start` process froze before starting the server. 
  * I _think_ adding `process.exit` to a few places fixed it. I've also added more logging, to provide visibility into the progress of the intermediary processes that occur before the server starts.

I hope this solves everything.