### PR TITLE
Add migration logic

### DIFF
--- a/preload.ts
+++ b/preload.ts
@@ -1,8 +1,10 @@
 import { DataFiller } from "./preload/data-filler";
 import { DirectoryPrebuilder } from "./preload/directory-prebuilder";
+import { DataMigrator } from "./server/data-migrating/migrations";
 
 (async () => {
   await DirectoryPrebuilder.prebuild();
   await DataFiller.fillDataFolder();
+  await DataMigrator.migrate();
   process.exit();
 })();

--- a/public/assets/ts/admin/page-editor/editor-nodes/EditorNode.tsx
+++ b/public/assets/ts/admin/page-editor/editor-nodes/EditorNode.tsx
@@ -24,6 +24,9 @@ export const EditorNode: React.FC<EditorNodeProps & { value: any }> = (
     return <EditorImageNode {...props} />;
   } else if (props.name.includes("Markdown")) {
     return <EditorMarkdownNode {...props} />;
+  } else if(props.name === "version") {
+    // @todo make a non-editable EditorNode child to display the file version. That or display it by some other means. 
+    return null;
   } else {
     return <EditorLabelNode {...props} />;
   }

--- a/server/data-base/cartoons/about-us.json
+++ b/server/data-base/cartoons/about-us.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "pageTitle": "About Cartoons",
   "heading": "MathSoc Cartoons",
   "coverPicSrc": "/assets/img/cartoons/mathsoc-cartoons-cover-full-scaled.jpg",

--- a/server/data-base/contact-us.json
+++ b/server/data-base/contact-us.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "staff": {
     "businessManager": {
       "name": "Rose Penner",

--- a/server/data-base/documents/budgets.json
+++ b/server/data-base/documents/budgets.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "descriptionMarkdown": "<p>If there are any questions or comments please email <a href=\"mailto:vpf@mathsoc.uwaterloo.ca\" rel=\"noopener noreferrer\" target=\"_blank\">vpf@mathsoc.uwaterloo.ca</a>.</p>",
   "budgets": [{ "year": 2023, "fall": "", "winter": "", "spring": "" }]
 }

--- a/server/data-base/documents/meetings.json
+++ b/server/data-base/documents/meetings.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "descriptionMarkdown": "Here is where you will find public agendas and minutes from past MathSoc meetings.",
   "meetingGroups": [
     {

--- a/server/data-base/elections.json
+++ b/server/data-base/elections.json
@@ -1,5 +1,5 @@
 {
+    "version": 1,
     "noElectionsMessage": "Election information is currently unavailable. Please check back later.",
     "electionsData": []
 }
-

--- a/server/data-base/get-involved/clubs.json
+++ b/server/data-base/get-involved/clubs.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "clubsHeader": "Clubs",
   "clubs": [
     {

--- a/server/data-base/get-involved/community.json
+++ b/server/data-base/get-involved/community.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "communityHeader": "Community Links",
   "communities": [
     {

--- a/server/data-base/get-involved/council.json
+++ b/server/data-base/get-involved/council.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "councilHeader": "What is Council?",
   "councilResponse": "Council represents the members of the Society by setting advocacy priorities, approving the budgets of clubs and executives as well as providing a voice for students (Bylaw 7.1). Council is further responsible to uphold the purpose of the Society and to hold the Executives and any other persons involved in Society affairs to account (Bylaw 7.6). Furthermore Council approves the termly budgets of execs and clubs.",
   "compositionOfCouncilHeader": "Composition of Council",

--- a/server/data-base/get-involved/volunteer-application.json
+++ b/server/data-base/get-involved/volunteer-application.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "programs": [
     "Honours Mathematics",
     "Actuarial Science",

--- a/server/data-base/get-involved/volunteer.json
+++ b/server/data-base/get-involved/volunteer.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "title": "Volunteer with MathSoc!",
   "subtext": "Volunteering with MathSoc is a great way to meet other people in your faculty. While some positions are time sensitive we welcome applications at anytime. If you have questions about a role we recommend sending the corresponding VP or club an email. If a position that you are interested in is not currently open and you wish to receive a notification when it opens please email the VPC at vpc@mathsoc.uwaterloo.ca about what positions you are interested in and ensure to check this page regularly. We look forward to meeting you!",
   "teams": [

--- a/server/data-base/resources/cheque-requests.json
+++ b/server/data-base/resources/cheque-requests.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "title": "Cheque Request Forms",
   "formLinks": [
     {

--- a/server/data-base/resources/discord-access.json
+++ b/server/data-base/resources/discord-access.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
     "title": "How to Access the MathSoc Discord",
     "subheader": "Feel free to join and ask any general or academic questions and contact any of the Mathsoc executives and councillors!",
     "steps": [

--- a/server/data-base/resources/mental-wellness.json
+++ b/server/data-base/resources/mental-wellness.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
     "title": "Mental Wellness at Waterloo",
     "subheader": "We encourage all students to seek support for mental wellness and health if needed.",
     "onCampus": "On-Campus Resources",

--- a/server/data-base/services/mathsoc-office.json
+++ b/server/data-base/services/mathsoc-office.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "title": "Our office",
   "descriptionMarkdown": "Located in MC3038, the MathSoc Office provides various services from board game and textbook rentals to free candy. See our services below!",
   "services": {

--- a/server/data-base/services/student-services.json
+++ b/server/data-base/services/student-services.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "sections": [
     {
       "title": "Locker Sign Out",

--- a/server/data-base/shared/execs.json
+++ b/server/data-base/shared/execs.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "execs": [
     {
       "name": "[President Name Here]",

--- a/server/data-base/shared/footer.json
+++ b/server/data-base/shared/footer.json
@@ -1,4 +1,5 @@
 {
+    "version": 1,
     "phoneNumber": "(519) 888-5467 x32324",
     "addressLine1": "200 University Avenue W,",
     "addressLine2": "Waterloo, ON N2L 3G1",

--- a/server/data-migrating/migrations.ts
+++ b/server/data-migrating/migrations.ts
@@ -1,0 +1,144 @@
+import fs from "fs";
+
+type VersionedData = { version?: number };
+
+/**
+ * When creating an UPDATE migration, ensure you:
+ * - update the base file in /server/data-base
+ * - update the schema in /server/types/schemas.ts
+ */
+interface UpdateMigration {
+  versionToApplyTo: number;
+  /** NEW is not an option, since this is handled automatically on startup; see preload.ts  */
+  type: "UPDATE";
+  /** Starts with a / */
+  path: string;
+  /**
+   * Accepts the current state of the data, and returns a new version that fits your updated schema.
+   */
+  migrator: (old: VersionedData) => object;
+}
+
+/**
+ * When creating a DELETE migration, ensure you
+ * - delete the base file in /server/data-base
+ */
+interface DeleteMigration {
+  type: "DELETE";
+  /** Starts with a / */
+  path: string;
+}
+
+type MigrationData = UpdateMigration | DeleteMigration;
+
+export class DataMigrator {
+  /**
+   * Once you're confident your migration has been applied across production and staging
+   * (i.e. a web dev lead has updated the production/staging site since you merged it),
+   * please remove it from this array.
+   */
+  private static migrations: MigrationData[] = [
+    /**
+      EXAMPLE MIGRATION:
+      {
+        type: "UPDATE",
+        versionToApplyTo: 1,
+        path: "/events.json",
+        migrator: (old) => {
+          return { ...old, someNewEditableField: "My default value" };
+        },
+      },
+     */
+  ];
+
+  static async migrate() {
+    for (const migration of DataMigrator.migrations) {
+      switch (migration.type) {
+        case "UPDATE": {
+          await DataMigrator.handleUpdateMigration(migration);
+          break;
+        }
+        case "DELETE": {
+          await DataMigrator.handleDeleteMigration(migration);
+          break;
+        }
+        default:
+          throw new Error("Invalid migration type: " + migration);
+      }
+    }
+  }
+
+  private static async handleUpdateMigration<OldSchema extends VersionedData>(
+    migration: UpdateMigration
+  ) {
+    if (!fs.existsSync(`server/data${migration.path}`)) {
+      console.error(
+        // escape characters are for red text
+        `\x1b[31mERROR:\x1b[0m Update migration on ${migration.path} failed; file does not exist.`
+      );
+      return;
+    }
+
+    if (
+      (await fs.promises.stat(`server/data${migration.path}`)).isDirectory()
+    ) {
+      // Unsupported because I don't know what this would mean? Could be supported in the future if needed.
+      throw new Error(
+        `Unsupported migration for ${migration.path}: Cannot update directory.`
+      );
+    }
+
+    const oldData = JSON.parse(
+      fs.readFileSync(`server/data${migration.path}`, "utf-8")
+    ) as OldSchema;
+
+    if (oldData.version === undefined) {
+      throw new Error(
+        `No version attribute found in existing data file for ${migration.path}`
+      );
+    }
+
+    if (oldData.version !== migration.versionToApplyTo) {
+      console.warn(
+        `Migration skipped from versions ${migration.versionToApplyTo} to ${
+          migration.versionToApplyTo + 1
+        } for file ${migration.path}.` +
+          ` ${migration.path} is at version ${oldData.version}.`
+      );
+
+      if (oldData.version > migration.versionToApplyTo) {
+        console.info(
+          "Consider deleting this migration once you're certain it has been applied to the staging and prod environments."
+        );
+      }
+    }
+
+    const newData = migration.migrator(oldData) as VersionedData;
+
+    if (Array.isArray(newData)) {
+      throw new Error(
+        "Must return object from migrator, otherwise we cannot version it."
+      );
+    }
+
+    newData.version = migration.versionToApplyTo + 1;
+
+    console.info(`Applying migration to update file: ${migration.path}`);
+
+    fs.writeFileSync(`server/data${migration.path}`, JSON.stringify(newData));
+  }
+
+  private static async handleDeleteMigration(migration: DeleteMigration) {
+    if (fs.existsSync(`server/data${migration.path}`)) {
+      if (
+        (await fs.promises.stat(`server/data${migration.path}`)).isDirectory()
+      ) {
+        /** @todo support deleting directories */
+        throw new Error("Deleting /data directories currently unsupported.");
+      }
+
+      console.info(`Applying migration to delete file: ${migration.path}`);
+      fs.unlinkSync(`server/data${migration.path}`);
+    }
+  }
+}

--- a/server/types/schemas.ts
+++ b/server/types/schemas.ts
@@ -1,7 +1,18 @@
 import { z } from "zod";
 
+/**
+ * It looks like you're modifying a schema!
+ *
+ * If you're editing an existing schema or deleting a schema, please write a simple migration
+ * from the old version of data on our dev environments and live site to your new version.
+ * You can do this in /server/data-migrating/migrations.ts.
+ *
+ * If you're adding a new schema, disregard this message :)
+ */
+
 const VolunteerDataSchema = z
   .object({
+    version: z.number(),
     title: z.string(),
     subtext: z.string(),
     teams: z.array(
@@ -28,6 +39,7 @@ const VolunteerDataSchema = z
 
 const VolunteerApplicationSchema = z
   .object({
+    version: z.number(),
     programs: z.array(z.string()),
     terms: z.array(z.string()),
   })
@@ -35,6 +47,7 @@ const VolunteerApplicationSchema = z
 
 const HomeDataSchema = z
   .object({
+    version: z.number(),
     socialText: z.string(),
     socialButtons: z.object({
       instagramMarkdown: z.string(),
@@ -45,6 +58,7 @@ const HomeDataSchema = z
   .strict();
 
 const ElectionsDataSchema = z.object({
+  version: z.number(),
   noElectionsMessage: z.string(),
   electionsData: z.array(
     z.object({
@@ -80,6 +94,7 @@ const ElectionsDataSchema = z.object({
 });
 
 const MentalWellnessDataSchema = z.object({
+  version: z.number(),
   title: z.string(),
   subheader: z.string(),
   onCampus: z.string(),
@@ -106,6 +121,7 @@ const MentalWellnessDataSchema = z.object({
 });
 
 const ChequeRequestSchema = z.object({
+  version: z.number(),
   title: z.string(),
   formLinks: z.array(
     z
@@ -176,6 +192,7 @@ const ChequeRequestSchema = z.object({
 });
 
 const DiscordAccessSchema = z.object({
+  version: z.number(),
   title: z.string(),
   subheader: z.string(),
   steps: z.array(
@@ -190,6 +207,7 @@ const DiscordAccessSchema = z.object({
 });
 
 const StudentServicesSchema = z.object({
+  version: z.number(),
   sections: z.array(
     z.object({
       title: z.string(),
@@ -212,6 +230,7 @@ const StudentServicesSchema = z.object({
 
 const ServicesMathsocOffice = z
   .object({
+    version: z.number(),
     title: z.string(),
     descriptionMarkdown: z.string(),
     services: z
@@ -236,6 +255,7 @@ const ServicesMathsocOffice = z
   .strict();
 
 const CartoonsAboutUsDataSchema = z.object({
+  version: z.number(),
   pageTitle: z.string(),
   heading: z.string(),
   coverPicSrc: z.string(),
@@ -282,6 +302,7 @@ const CartoonsAboutUsDataSchema = z.object({
 
 const CouncilDataSchema = z
   .object({
+    version: z.number(),
     councilHeader: z.string(),
     councilResponse: z.string(),
     compositionOfCouncilHeader: z.string(),
@@ -302,6 +323,7 @@ const CouncilDataSchema = z
   .strict();
 
 const ContactUsDataSchema = z.object({
+  version: z.number(),
   staff: z.object({
     businessManager: z
       .object({
@@ -324,6 +346,7 @@ const ContactUsDataSchema = z.object({
 
 const SharedFooterSchema = z
   .object({
+    version: z.number(),
     phoneNumber: z.string(),
     addressLine1: z.string(),
     addressLine2: z.string(),
@@ -342,6 +365,7 @@ const SharedFooterSchema = z
   .strict();
 
 const SharedExecsSchema = z.object({
+  version: z.number(),
   execs: z.array(
     z.object({
       name: z.string(),
@@ -353,6 +377,7 @@ const SharedExecsSchema = z.object({
 });
 
 const ClubsSchema = z.object({
+  version: z.number(),
   clubsHeader: z.string(),
   clubs: z.array(
     z.object({
@@ -366,6 +391,7 @@ const ClubsSchema = z.object({
 
 const CommunitySchema = z
   .object({
+    version: z.number(),
     communityHeader: z.string(),
     communities: z.array(
       z
@@ -382,6 +408,7 @@ const CommunitySchema = z
 
 const DocumentsBudgetsSchema = z
   .object({
+    version: z.number(),
     descriptionMarkdown: z.string(),
     budgets: z.array(
       z
@@ -398,6 +425,7 @@ const DocumentsBudgetsSchema = z
 
 const DocumentsMeetingsSchema = z
   .object({
+    version: z.number(),
     descriptionMarkdown: z.string(),
     meetingGroups: z.array(
       z


### PR DESCRIPTION
### why

At the moment, we have a slight problem with our `/data` folder. If someone wants to edit it (like in https://github.com/MathSoc/mathsoc-website/pull/223), we can't actually apply that change without completely overwriting old data. This presents a serious problem to the maintainability of the website - we often need to be able to update the data schemas when updating pages; if we always had to copy over data to the new schema manually, it would be really painful.

### what

This applies the idea of a SQL database's "migration script" to solve the issue. Every time the site loads, `DataMigrator` will run through any migration configs it has been passed. These configs are really simple objects - just a file path, a target file version, and a mapper function from the old data to the new. It's even simpler for deleted files. This is designed to be idempotent - it won't break on repeat startups. Further, it can be managed in-code. We don't need to manually change things in the data folder to apply a change.

Closes #227