### PR TITLE
More migration tweaks

### DIFF
--- a/server/data-migrating/migrations.ts
+++ b/server/data-migrating/migrations.ts
@@ -53,6 +53,18 @@ export class DataMigrator {
         },
       },
      */
+    {
+      type: "UPDATE",
+      dateAdded: new Date("2024-06-17"),
+      path: "/cartoons/about-us.json",
+      migrator: (old) => {
+        return {
+          ...old,
+          desktopCoverPicImage: old.coverPicSrc,
+          mobileCoverPicImage: old.coverPicSrcMobile,
+        };
+      },
+    },
   ];
 
   static async migrate() {
@@ -140,13 +152,13 @@ export class DataMigrator {
       validateDataPath(migration.path, newData);
     } catch (e) {
       console.error(
-        `Migration for ${
+        `\x1b[31mMIGRATION ERROR:\x1b[0m Migration for ${
           migration.path
         } failed validation. Attempted new state of the file:\n ${JSON.stringify(
           newData,
           null,
           2
-        )}`
+        )}\n\n\x1b[31mProblems with this new state listed below:\x1b[0m\n`
       );
 
       throw e;

--- a/server/data-migrating/migrations.ts
+++ b/server/data-migrating/migrations.ts
@@ -53,18 +53,6 @@ export class DataMigrator {
         },
       },
      */
-    {
-      type: "UPDATE",
-      dateAdded: new Date("2024-06-17"),
-      path: "/cartoons/about-us.json",
-      migrator: (old) => {
-        return {
-          ...old,
-          desktopCoverPicImage: old.coverPicSrc,
-          mobileCoverPicImage: old.coverPicSrcMobile,
-        };
-      },
-    },
   ];
 
   static async migrate() {

--- a/server/types/schemas.ts
+++ b/server/types/schemas.ts
@@ -57,176 +57,186 @@ const HomeDataSchema = z
   })
   .strict();
 
-const ElectionsDataSchema = z.object({
-  lastMigrationId: z.string().datetime(),
-  noElectionsMessage: z.string(),
-  electionsData: z.array(
-    z.object({
-      term: z.string(),
-      electionState: z.string(),
-      candidates: z.array(
-        z
-          .object({
-            name: z.string(),
-            position: z.string(),
-            elected: z.boolean(),
-            platformMarkdown: z.string(),
-          })
-          .strict()
-      ),
-      decisions: z.array(
-        z
-          .object({
-            candidate: z.string(),
-            date: z.string(),
-            allegationMarkdown: z.string().optional(),
-            defenseMarkdown: z.string().optional(),
-            decisionMarkdown: z.string().optional(),
-            penalties: z.array(z.string()).optional(),
-            penaltyDescriptionMarkdown: z.string().optional(),
-            appealMarkdown: z.string().optional(),
-            appealDecisionMarkdown: z.string().optional(),
-          })
-          .strict()
-      ),
-    })
-  ),
-});
+const ElectionsDataSchema = z
+  .object({
+    lastMigrationId: z.string().datetime(),
+    noElectionsMessage: z.string(),
+    electionsData: z.array(
+      z.object({
+        term: z.string(),
+        electionState: z.string(),
+        candidates: z.array(
+          z
+            .object({
+              name: z.string(),
+              position: z.string(),
+              elected: z.boolean(),
+              platformMarkdown: z.string(),
+            })
+            .strict()
+        ),
+        decisions: z.array(
+          z
+            .object({
+              candidate: z.string(),
+              date: z.string(),
+              allegationMarkdown: z.string().optional(),
+              defenseMarkdown: z.string().optional(),
+              decisionMarkdown: z.string().optional(),
+              penalties: z.array(z.string()).optional(),
+              penaltyDescriptionMarkdown: z.string().optional(),
+              appealMarkdown: z.string().optional(),
+              appealDecisionMarkdown: z.string().optional(),
+            })
+            .strict()
+        ),
+      })
+    ),
+  })
+  .strict();
 
-const MentalWellnessDataSchema = z.object({
-  lastMigrationId: z.string().datetime(),
-  title: z.string(),
-  subheader: z.string(),
-  onCampus: z.string(),
-  offCampus: z.string(),
-  bottomText: z.string(),
-  onCampusChildren: z.array(
-    z
-      .object({
-        title: z.string(),
-        text: z.array(z.string()),
-        link: z.string(),
-      })
-      .strict()
-  ),
-  offCampusChildren: z.array(
-    z
-      .object({
-        title: z.string(),
-        text: z.array(z.string()),
-        link: z.string(),
-      })
-      .strict()
-  ),
-});
-
-const ChequeRequestSchema = z.object({
-  lastMigrationId: z.string().datetime(),
-  title: z.string(),
-  formLinks: z.array(
-    z
-      .object({
-        title: z.string(),
-        link: z.string(),
-      })
-      .strict()
-  ),
-  process: z
-    .object({
-      header: z.string(),
-      description: z.string(),
-      requirementsSubheader: z.string(),
-      requirements: z.array(
-        z
-          .object({
-            descriptionMarkdown: z.string(),
-          })
-          .strict()
-      ),
-    })
-    .strict(),
-  additionalDocumentationItems: z
-    .object({
-      header: z.string(),
-      items: z.array(
-        z.object({
+const MentalWellnessDataSchema = z
+  .object({
+    lastMigrationId: z.string().datetime(),
+    title: z.string(),
+    subheader: z.string(),
+    onCampus: z.string(),
+    offCampus: z.string(),
+    bottomText: z.string(),
+    onCampusChildren: z.array(
+      z
+        .object({
           title: z.string(),
-          description: z.string(),
+          text: z.array(z.string()),
+          link: z.string(),
         })
-      ),
-    })
-    .strict(),
-  frequentlyAskedQuestions: z
-    .object({
-      header: z.string(),
-      questions: z.array(
-        z
-          .object({
-            question: z.string(),
-            questionMarkdown: z.string(),
-          })
-          .strict()
-      ),
-    })
-    .strict(),
-  otherForms: z
-    .object({
-      header: z.string(),
-      footnote: z.string(),
-      forms: z.array(
-        z
-          .object({
-            title: z.string(),
-            link: z.string(),
-          })
-          .strict()
-      ),
-    })
-    .strict(),
-  mathSocFees: z
-    .object({
-      header: z.string(),
-      description: z.string(),
-    })
-    .strict(),
-});
+        .strict()
+    ),
+    offCampusChildren: z.array(
+      z
+        .object({
+          title: z.string(),
+          text: z.array(z.string()),
+          link: z.string(),
+        })
+        .strict()
+    ),
+  })
+  .strict();
 
-const DiscordAccessSchema = z.object({
-  lastMigrationId: z.string().datetime(),
-  title: z.string(),
-  subheader: z.string(),
-  steps: z.array(
-    z
+const ChequeRequestSchema = z
+  .object({
+    lastMigrationId: z.string().datetime(),
+    title: z.string(),
+    formLinks: z.array(
+      z
+        .object({
+          title: z.string(),
+          link: z.string(),
+        })
+        .strict()
+    ),
+    process: z
       .object({
+        header: z.string(),
+        description: z.string(),
+        requirementsSubheader: z.string(),
+        requirements: z.array(
+          z
+            .object({
+              descriptionMarkdown: z.string(),
+            })
+            .strict()
+        ),
+      })
+      .strict(),
+    additionalDocumentationItems: z
+      .object({
+        header: z.string(),
+        items: z.array(
+          z.object({
+            title: z.string(),
+            description: z.string(),
+          })
+        ),
+      })
+      .strict(),
+    frequentlyAskedQuestions: z
+      .object({
+        header: z.string(),
+        questions: z.array(
+          z
+            .object({
+              question: z.string(),
+              questionMarkdown: z.string(),
+            })
+            .strict()
+        ),
+      })
+      .strict(),
+    otherForms: z
+      .object({
+        header: z.string(),
+        footnote: z.string(),
+        forms: z.array(
+          z
+            .object({
+              title: z.string(),
+              link: z.string(),
+            })
+            .strict()
+        ),
+      })
+      .strict(),
+    mathSocFees: z
+      .object({
+        header: z.string(),
+        description: z.string(),
+      })
+      .strict(),
+  })
+  .strict();
+
+const DiscordAccessSchema = z
+  .object({
+    lastMigrationId: z.string().datetime(),
+    title: z.string(),
+    subheader: z.string(),
+    steps: z.array(
+      z
+        .object({
+          title: z.string(),
+          text: z.string(),
+          img: z.string(),
+        })
+        .strict()
+    ),
+  })
+  .strict();
+
+const StudentServicesSchema = z
+  .object({
+    lastMigrationId: z.string().datetime(),
+    sections: z.array(
+      z.object({
         title: z.string(),
-        text: z.string(),
+        description: z.string(),
+        subdescription: z.string(),
+        items: z.array(
+          z.object({
+            item: z.string(),
+          })
+        ),
+        contacts: z.array(
+          z.object({
+            contact: z.string(),
+          })
+        ),
         img: z.string(),
       })
-      .strict()
-  ),
-});
-
-const StudentServicesSchema = z.object({
-  lastMigrationId: z.string().datetime(),
-  sections: z.array(
-    z.object({
-      title: z.string(),
-      description: z.string(),
-      subdescription: z.string(),
-      items: z.array(
-        z.object({
-          item: z.string(),
-        })
-      ),
-      contacts: z.array(
-        z.object({
-          contact: z.string(),
-        })
-      ),
-      img: z.string(),
-    })
-  ),
-});
+    ),
+  })
+  .strict();
 
 const ServicesMathsocOffice = z
   .object({
@@ -254,51 +264,53 @@ const ServicesMathsocOffice = z
   })
   .strict();
 
-const CartoonsAboutUsDataSchema = z.object({
-  lastMigrationId: z.string().datetime(),
-  pageTitle: z.string(),
-  heading: z.string(),
-  coverPicSrc: z.string(),
-  coverPicSrcMobile: z.string(),
-  comicExample: z.string(),
-  subheading: z.string(),
-  subheadingCaptionMarkdown: z.string(),
-  joinUs: z.string(),
-  applicationsCaption: z.string(),
-  signupMarkdown: z.string(),
-  buttons: z.object({
-    team: z
+const CartoonsAboutUsDataSchema = z
+  .object({
+    lastMigrationId: z.string().datetime(),
+    pageTitle: z.string(),
+    heading: z.string(),
+    coverPicSrc: z.string(),
+    coverPicSrcMobile: z.string(),
+    comicExample: z.string(),
+    subheading: z.string(),
+    subheadingCaptionMarkdown: z.string(),
+    joinUs: z.string(),
+    applicationsCaption: z.string(),
+    signupMarkdown: z.string(),
+    buttons: z.object({
+      team: z
+        .object({
+          text: z.string(),
+          link: z.string(),
+        })
+        .strict(),
+      archive: z
+        .object({
+          text: z.string(),
+          link: z.string(),
+        })
+        .strict(),
+    }),
+    carouselImages: z.array(z.string()),
+    getInTouch: z.string(),
+    socialButtons: z
       .object({
-        text: z.string(),
-        link: z.string(),
+        instagramMarkdown: z.string(),
+        facebookMarkdown: z.string(),
+        feedbackMarkdown: z.string(),
+        emailMarkdown: z.string(),
       })
       .strict(),
-    archive: z
+    socialLinks: z
       .object({
-        text: z.string(),
-        link: z.string(),
+        instagram: z.string(),
+        facebook: z.string(),
+        feedback: z.string(),
+        email: z.string(),
       })
       .strict(),
-  }),
-  carouselImages: z.array(z.string()),
-  getInTouch: z.string(),
-  socialButtons: z
-    .object({
-      instagramMarkdown: z.string(),
-      facebookMarkdown: z.string(),
-      feedbackMarkdown: z.string(),
-      emailMarkdown: z.string(),
-    })
-    .strict(),
-  socialLinks: z
-    .object({
-      instagram: z.string(),
-      facebook: z.string(),
-      feedback: z.string(),
-      email: z.string(),
-    })
-    .strict(),
-});
+  })
+  .strict();
 
 const CouncilDataSchema = z
   .object({
@@ -322,27 +334,29 @@ const CouncilDataSchema = z
   })
   .strict();
 
-const ContactUsDataSchema = z.object({
-  lastMigrationId: z.string().datetime(),
-  staff: z.object({
-    businessManager: z
-      .object({
-        name: z.string(),
-        role: z.string(),
-        email: z.string(),
-      })
-      .strict(),
-  }),
-  locations: z.array(
-    z
-      .object({
-        name: z.string(),
-        room: z.string(),
-        img: z.string(),
-      })
-      .strict()
-  ),
-});
+const ContactUsDataSchema = z
+  .object({
+    lastMigrationId: z.string().datetime(),
+    staff: z.object({
+      businessManager: z
+        .object({
+          name: z.string(),
+          role: z.string(),
+          email: z.string(),
+        })
+        .strict(),
+    }),
+    locations: z.array(
+      z
+        .object({
+          name: z.string(),
+          room: z.string(),
+          img: z.string(),
+        })
+        .strict()
+    ),
+  })
+  .strict();
 
 const SharedFooterSchema = z
   .object({
@@ -364,30 +378,34 @@ const SharedFooterSchema = z
   })
   .strict();
 
-const SharedExecsSchema = z.object({
-  lastMigrationId: z.string().datetime(),
-  execs: z.array(
-    z.object({
-      name: z.string(),
-      role: z.string(),
-      email: z.string(),
-      image: z.string(),
-    })
-  ),
-});
+const SharedExecsSchema = z
+  .object({
+    lastMigrationId: z.string().datetime(),
+    execs: z.array(
+      z.object({
+        name: z.string(),
+        role: z.string(),
+        email: z.string(),
+        image: z.string(),
+      })
+    ),
+  })
+  .strict();
 
-const ClubsSchema = z.object({
-  lastMigrationId: z.string().datetime(),
-  clubsHeader: z.string(),
-  clubs: z.array(
-    z.object({
-      title: z.string(),
-      descriptionMarkdown: z.string(),
-      link: z.string(),
-      icon: z.string(),
-    })
-  ),
-});
+const ClubsSchema = z
+  .object({
+    lastMigrationId: z.string().datetime(),
+    clubsHeader: z.string(),
+    clubs: z.array(
+      z.object({
+        title: z.string(),
+        descriptionMarkdown: z.string(),
+        link: z.string(),
+        icon: z.string(),
+      })
+    ),
+  })
+  .strict();
 
 const CommunitySchema = z
   .object({


### PR DESCRIPTION
Two things:
1) Better logging of migration failures
2) Updates schemas to all use `.strict()`. Most of them already did this, but there were a few we had missed. This ensures that we don't accidentally have extra attributes in our data files; instead, they match _exactly_ what is specified in the schema. (e.g. beforehand, if you had a migration to rename `data.foo` to `data.bar`, `data.foo` could still secretly exist in the `data` file. This is no longer this case).