### PR TITLE
Enable editor item folding

### DIFF
--- a/public/assets/sass/admin/generic-editor.scss
+++ b/public/assets/sass/admin/generic-editor.scss
@@ -22,7 +22,7 @@
         padding-bottom: 8px;
       }
 
-        > .editor-node-content-container {
+      > .editor-node-content-container {
         background-color: var(--background-colour);
         padding: 4px 16px;
       }
@@ -32,6 +32,11 @@
   .editor-node-label-bar {
     display: inline-flex;
     width: 100%;
+
+    .editor-node-toggle {
+      padding: 0 4px;
+      cursor: pointer;
+    }
 
     .editor-node-buttons {
       flex: 1;
@@ -75,7 +80,7 @@
 
       button {
         cursor: pointer;
-        
+
         &:focus-visible {
           outline: auto;
         }
@@ -84,7 +89,7 @@
           background-color: var(--background-hover);
         }
       }
-      
+
       .image-node-item {
         flex: 1;
         display: block;
@@ -92,7 +97,6 @@
         background-color: var(--background-colour-3);
       }
     }
-
 
     .hidden-file-uploader {
       display: none;

--- a/public/assets/ts/admin/page-editor/editor-nodes/EditorNodeTemplate.tsx
+++ b/public/assets/ts/admin/page-editor/editor-nodes/EditorNodeTemplate.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 export interface EditorNodeProps {
   name: string;
@@ -20,6 +20,8 @@ export const EditorNodeTemplate: React.FC<
     labelId?: string;
   }
 > = ({ name, children, labelId, headerButtons, theme }) => {
+  const [isUnfolded, setIsUnfolded] = useState<boolean>(true);
+
   const getFormattedName = (name: string) => {
     return name
       ?.replace(/([A-Z])/g, " $1")
@@ -36,6 +38,12 @@ export const EditorNodeTemplate: React.FC<
       className={`editor-node-container ${theme ? `editor-node-${theme}` : ""}`}
     >
       <div className="editor-node-label-bar">
+        <span
+          className="editor-node-toggle"
+          onClick={() => setIsUnfolded(!isUnfolded)}
+        >
+          {isUnfolded ? "–" : "+"}&nbsp;
+        </span>
         {labelId ? (
           <label className="editor-label" id={labelId}>
             {getFormattedName(name)}
@@ -57,7 +65,9 @@ export const EditorNodeTemplate: React.FC<
           })}
         </div>
       </div>
-      <div className="editor-node-content-container">{children}</div>
+      {isUnfolded ? (
+        <div className="editor-node-content-container">{children}</div>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
Adds a folding mechanism to the EditorNodes, allowing admins to see better and scroll less :)

<img width="441" alt="image" src="https://github.com/MathSoc/mathsoc-website/assets/37753525/32068fb3-33c3-4c9a-837c-6b0c712f9dbc">

this is part of my master plan to try to use the EditorNodes to handle uploads to the cartoons archive. 