### PR TITLE
Prevent accidental image overwrites

### DIFF
--- a/server/api/controllers/image-controller.ts
+++ b/server/api/controllers/image-controller.ts
@@ -2,7 +2,7 @@
 import { Request, Response } from "express";
 import { UploadedFile } from "express-fileupload";
 import { Image, ImageWithFile } from "../../types/image";
-import {
+import fs, {
   Dirent,
   existsSync,
   lstatSync,
@@ -122,6 +122,11 @@ export class ImageController extends AbstractFileController<
 
     try {
       for (const image of images) {
+        if (existsSync(image.path)) {
+          errors.push(`File ${image.fileName} already exists`);
+          continue;
+        }
+
         await image.file?.mv(image.path);
         this.logger.info(`${image.fileName} uploaded to ${image.path}`);
       }


### PR DESCRIPTION
idk what happened to the git diff. i promise i only changed lines 124-128. ;-;

<img width="619" alt="image" src="https://github.com/MathSoc/mathsoc-website/assets/37753525/acbdd73b-56a5-44b9-9ff9-f711f663a38c">

Adds a check upon image upload that the image the user is trying to upload does not already exist. This prevents accidental overwriting of existing images.