### PR TITLE
Update pink buttons

### DIFF
--- a/public/assets/sass/mixins/_pink-button.scss
+++ b/public/assets/sass/mixins/_pink-button.scss
@@ -9,13 +9,23 @@
   max-height: 60px;
   padding: 1em 2em;
   background-color: var(--mathsoc-pink);
+  border-radius: 24px;
+  display: inline-block;
   border: none;
+  text-decoration: none;
   color: white;
   font-family: var(--primary-font);
   cursor: pointer;
   transition: background-color 0.15s;
+  border: 2px solid var(--mathsoc-pink);
 
-  &:hover {
-    background-color: var(--mathsoc-pink-2);
+  &:visited {
+    color: white;
+  }
+
+  &:hover,
+  &:focus-visible {
+    background-color: white;
+    color: var(--mathsoc-pink);
   }
 }

--- a/public/assets/sass/pages/cartoons/about.scss
+++ b/public/assets/sass/pages/cartoons/about.scss
@@ -1,5 +1,5 @@
-@import "../mixins/banner-image";
-@import "../mixins/pink-button";
+@import "../../mixins/banner-image";
+@import "../../mixins/pink-button";
 
 .title {
   color: var(--accent-colour-1);
@@ -74,18 +74,13 @@ section {
   }
 
   .button-row {
-    justify-content: space-between;
-    .col {
-      width: 20%;
-
-      @media (max-width: 1600px) {
-        width: 100%;
-      }
-    }
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 16px;
 
     .pink-button {
-      max-width: initial;
-      min-width: 100%;
+      margin: 0;
     }
   }
 

--- a/views/mixins/pink-button.pug
+++ b/views/mixins/pink-button.pug
@@ -1,7 +1,6 @@
 //- Types: pink, small
 mixin pink-button(text, id, href) 
   if(href) 
-    a(href=href class="pink-button-link")
-      button(class="pink-button", id=id)!=text
+    a(href=href class="pink-button" id=id)!=text
   else 
     button(class="pink-button", id=id)=text

--- a/views/pages/cartoons/about-us.pug
+++ b/views/pages/cartoons/about-us.pug
@@ -4,7 +4,7 @@ block title
     title #{data.pageTitle} &#8211; MathSoc
 
 append styles
-    link(href="/assets/css/pages/about-cartoons.css" rel="stylesheet")
+    link(href="/assets/css/pages/cartoons/about.css" rel="stylesheet")
 
 append scripts
     script(src="/assets/js/carousel.js" defer)
@@ -34,13 +34,9 @@ block body
                     +carousel(data.carouselImages)
             div(class="title get-in-touch")
                 h1 #{data.getInTouch}
-            div(class="row button-row")
-                div(class="col")
-                    +pink-button(data.socialButtons.emailMarkdown, "email", data.socialLinks.email)
-                div(class="col")
-                    +pink-button(data.socialButtons.feedbackMarkdown, "feedback", data.socialLinks.feedback)
-                div(class="col")
-                    +pink-button(data.socialButtons.instagramMarkdown, "instagram", data.socialLinks.instagram)
-                div(class="col")
-                    +pink-button(data.socialButtons.facebookMarkdown, "facebook", data.socialLinks.facebook)
+            div(class="button-row")
+                +pink-button(data.socialButtons.emailMarkdown, "email", data.socialLinks.email)
+                +pink-button(data.socialButtons.feedbackMarkdown, "feedback", data.socialLinks.feedback)
+                +pink-button(data.socialButtons.instagramMarkdown, "instagram", data.socialLinks.instagram)
+                +pink-button(data.socialButtons.facebookMarkdown, "facebook", data.socialLinks.facebook)
 


### PR DESCRIPTION
I realized that our `+pink-button` mixin wasn't behaving well with keyboard navigation - when you gave it focus, the outline was creating square edges around a round shape.

This updates the `+pink-button` to 
* have an outline that hugs the outline of the button
* look prettier when hovered over
* have the hover style appear when given keyboard focus

It also updates the cartoons page to look marginally better.

### old

<img width="357" alt="image" src="https://github.com/user-attachments/assets/633e528a-9266-4a43-9f36-022f22220765">


### new 

<img width="373" alt="image" src="https://github.com/user-attachments/assets/e36c96b0-d9e3-4c03-a18a-fc555d5d28e2">
