### PR TITLE
Add exam-bank-only switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,5 @@ IS_DEVELOPMENT=false
 GOOGLE_CLIENT_ID=put_client_id_from_google_cloud_console_here
 GOOGLE_CLIENT_SECRET=put_client_secret_from_google_cloud_console_here
 GOOGLE_AUTH_SUCCESS_REDIRECT=https://staging9000.mathsoc.uwaterloo.ca/auth-redirect
+
+EXAM_BANK_ONLY=false

--- a/config.ts
+++ b/config.ts
@@ -11,6 +11,7 @@ const requiredTokens = {
 const requiredForProdTokens = {
   WATERLOO_OPEN_API_BASE_URL: process.env.WATERLOO_OPEN_API_BASE_URL,
   WATERLOO_OPEN_API_KEY: process.env.WATERLOO_OPEN_API_KEY,
+  EXAM_BANK_ONLY: process.env.EXAM_BANK_ONLY == "true",
 };
 
 // Will only prevent server initialization on prod/staging

--- a/server/routes/controllers/page-loader.ts
+++ b/server/routes/controllers/page-loader.ts
@@ -2,13 +2,16 @@ import { Request, RequestHandler, Response, Router } from "express";
 import fs from "fs";
 import { ReadWriteController } from "../../api/controllers/read-write-controller";
 import { PageInflow, PageOutflow } from "../../types/routing.js";
+import tokens from "../../../config";
 
 /**
  * Contains functions related to the construction of new page routes and the population of
  * the pug views those routes redirect to
  */
 export class PageLoader {
-  static navItems = require("../../config/navbar.json");
+  static navItems = tokens.EXAM_BANK_ONLY
+    ? []
+    : require("../../config/navbar.json");
   static footer = require("../../data/shared/footer.json");
 
   /**
@@ -62,6 +65,7 @@ export class PageLoader {
       data: page.ref ? await PageLoader.getPageDataSource(page.ref) : null,
       title: page.title,
       ref: page.ref,
+      examBankOnly: tokens.EXAM_BANK_ONLY,
     };
 
     // Load any additional sources of data for the page, such as shared data files

--- a/server/routes/public-routes.ts
+++ b/server/routes/public-routes.ts
@@ -1,9 +1,12 @@
 import express from "express";
 import pages from "../config/pages.json";
 import { PageLoader } from "./controllers/page-loader";
+import tokens from "../../config";
 
 const router = express.Router();
 
-PageLoader.buildRoutes(pages, router, (page) => page);
+if (!tokens.EXAM_BANK_ONLY) {
+  PageLoader.buildRoutes(pages, router, (page) => page);
+}
 
 export default router;

--- a/server/types/routing.ts
+++ b/server/types/routing.ts
@@ -22,6 +22,7 @@ export interface PageOutflow {
   ref?: string;
   sources?: Record<string, object | any[] | null>;
   dataEndpoints?: string[];
+  examBankOnly: boolean;
 }
 
 export interface AdminPageOutflow extends PageOutflow {

--- a/views/partials/footer.pug
+++ b/views/partials/footer.pug
@@ -1,16 +1,17 @@
-div(id="footer")
-    div(class="section")
-        b="©" + new Date().getFullYear() + " Mathsoc"
-    hr
-    div(class="section")
-        div(class="link-section")
-            a(href="/") Home
-            a(href="/contact-us") Contact
-        div(class="social-section")
-            div(class="socials")
-                a(href="" + footer.socialLinks.discord target="_blank")
-                    img(src="/assets/img/social/discord.svg" alt="Discord Icon")
-                a(href="" + footer.socialLinks.instagram target="_blank")
-                    img(src="/assets/img/social/instagram.svg" alt="Instagram Icon")
-                a(href="" + footer.socialLinks.mail + "" target="_blank" class="mail-icon")
-                    img(src="/assets/img/social/mail.svg" alt="Mail Icon")
+if !examBankOnly
+    div(id="footer")
+        div(class="section")
+            b="©" + new Date().getFullYear() + " Mathsoc"
+        hr
+        div(class="section")
+            div(class="link-section")
+                a(href="/") Home
+                a(href="/contact-us") Contact
+            div(class="social-section")
+                div(class="socials")
+                    a(href="" + footer.socialLinks.discord target="_blank")
+                        img(src="/assets/img/social/discord.svg" alt="Discord Icon")
+                    a(href="" + footer.socialLinks.instagram target="_blank")
+                        img(src="/assets/img/social/instagram.svg" alt="Instagram Icon")
+                    a(href="" + footer.socialLinks.mail + "" target="_blank" class="mail-icon")
+                        img(src="/assets/img/social/mail.svg" alt="Mail Icon")

--- a/views/partials/navbar.pug
+++ b/views/partials/navbar.pug
@@ -2,9 +2,10 @@ a.skip-to-main-content(href='#body') Skip to main content
 
 nav(id="navbar")
   div(id="inner-navbar")
-    a(href="/" class="nav-logo-container") 
-      img(src="/assets/img/icons/horizontal-logo.svg" class="nav-logo" id="pink-logo" alt="MathSoc Logo.  Click to return to homepage")
-      img(src="/assets/img/icons/horizontal-logo-white.svg" class="nav-logo" id="white-logo" alt="MathSoc Logo.  Click to return to homepage")
+    if !examBankOnly
+      a(href="/" class="nav-logo-container") 
+        img(src="/assets/img/icons/horizontal-logo.svg" class="nav-logo" id="pink-logo" alt="MathSoc Logo.  Click to return to homepage")
+        img(src="/assets/img/icons/horizontal-logo-white.svg" class="nav-logo" id="white-logo" alt="MathSoc Logo.  Click to return to homepage")
     ul(class="items")
       each category in navItems
         li(class="dropdown")


### PR DESCRIPTION
Adds a switch that will allow us to simplify the website to only include the exam bank. 

With this, we'll be able to host the new website as only the exam bank. This will allow us to finally (FINALLY) deprecate the old services server currently hosting the exam bank.