### PR TITLE
Quick Fix to Navbar with `EXAM_BANK_ONLY`

### DIFF
--- a/views/partials/navbar.pug
+++ b/views/partials/navbar.pug
@@ -2,27 +2,33 @@ a.skip-to-main-content(href='#body') Skip to main content
 
 nav(id="navbar")
   div(id="inner-navbar")
-    a(href="/" class="nav-logo-container") 
-      img(src="/assets/img/icons/horizontal-logo.svg" class="nav-logo" id="pink-logo" alt="MathSoc Logo.  Click to return to homepage")
-      img(src="/assets/img/icons/horizontal-logo-white.svg" class="nav-logo" id="white-logo" alt="MathSoc Logo.  Click to return to homepage")
-    
+    if examBankOnly
+      div(href="/" class="nav-logo-container") 
+        img(src="/assets/img/icons/horizontal-logo.svg" class="nav-logo" id="pink-logo" alt="MathSoc Logo.  Click to return to homepage")
+        img(src="/assets/img/icons/horizontal-logo-white.svg" class="nav-logo" id="white-logo" alt="MathSoc Logo.  Click to return to homepage")
+    else 
+      a(href="/" class="nav-logo-container") 
+        img(src="/assets/img/icons/horizontal-logo.svg" class="nav-logo" id="pink-logo" alt="MathSoc Logo.  Click to return to homepage")
+        img(src="/assets/img/icons/horizontal-logo-white.svg" class="nav-logo" id="white-logo" alt="MathSoc Logo.  Click to return to homepage")
+
     if !examBankOnly
       ul(class="items")
-      each category in navItems
-        li(class="dropdown")
-          if !category.ref
-            button(class="dropdown-button") #{category.title}
-          else 
-            a(href=category.ref)
-              div(class="dropdown-button") #{category.title}
-          - var length = category.children ? category.children.length : 0;
-          if length
-            div(class="dropdown-content")
-              each item in category.children
-                a(href=""+ item.ref +"") #{item.title}
+        each category in navItems
+          li(class="dropdown")
+            if !category.ref
+              button(class="dropdown-button") #{category.title}
+            else 
+              a(href=category.ref)
+                div(class="dropdown-button") #{category.title}
+            - var length = category.children ? category.children.length : 0;
+            if length
+              div(class="dropdown-content")
+                each item in category.children
+                  a(href=""+ item.ref +"") #{item.title}
+
     if !examBankOnly
       button(id="mobile-menu-button")
-      img(src="/assets/img/icons/single-downvote.svg")
+        img(src="/assets/img/icons/single-downvote.svg")
 
 nav(id="mobile-nav")
   ul(class="items")

--- a/views/partials/navbar.pug
+++ b/views/partials/navbar.pug
@@ -2,11 +2,12 @@ a.skip-to-main-content(href='#body') Skip to main content
 
 nav(id="navbar")
   div(id="inner-navbar")
+    a(href="/" class="nav-logo-container") 
+      img(src="/assets/img/icons/horizontal-logo.svg" class="nav-logo" id="pink-logo" alt="MathSoc Logo.  Click to return to homepage")
+      img(src="/assets/img/icons/horizontal-logo-white.svg" class="nav-logo" id="white-logo" alt="MathSoc Logo.  Click to return to homepage")
+    
     if !examBankOnly
-      a(href="/" class="nav-logo-container") 
-        img(src="/assets/img/icons/horizontal-logo.svg" class="nav-logo" id="pink-logo" alt="MathSoc Logo.  Click to return to homepage")
-        img(src="/assets/img/icons/horizontal-logo-white.svg" class="nav-logo" id="white-logo" alt="MathSoc Logo.  Click to return to homepage")
-    ul(class="items")
+      ul(class="items")
       each category in navItems
         li(class="dropdown")
           if !category.ref
@@ -19,7 +20,8 @@ nav(id="navbar")
             div(class="dropdown-content")
               each item in category.children
                 a(href=""+ item.ref +"") #{item.title}
-    button(id="mobile-menu-button")
+    if !examBankOnly
+      button(id="mobile-menu-button")
       img(src="/assets/img/icons/single-downvote.svg")
 
 nav(id="mobile-nav")


### PR DESCRIPTION
Aaa its my first commit, which should fix https://github.com/MathSoc/mathsoc-website/issues/276 and https://github.com/MathSoc/mathsoc-website/issues/285

Added extra EXAM_BANK_ONLY checks to the navbar, and added a separate `<div>` variant to the logo so it is unclickable if on that given mode, since it seems right now clicking it leads to "/" and an error.

This should not have taken this long, i kinda forgot about this... apologies

Testing
- [x] Seems to show navbar without content on `EXAM_BANK_ONLY` mode
- [x] on normal mode, it works the same

P.S. Totally didn't mess up the normal mode halfway through because I inadvertibly messed up pug which is whitespace determinant like python which i did not realize oh no 