### PR TITLE
Added X to remove staged uploads from exam bank (#292)

### DIFF
--- a/public/assets/sass/admin/exam-bank.scss
+++ b/public/assets/sass/admin/exam-bank.scss
@@ -71,13 +71,20 @@ hr {
       font-size: 0.8em;
     }
 
-    .delete-btn {
-      width: max-content;
+    .remove-upload-btn {
+      label {
+        display: none;
+      }
 
-      background-color: none;
-      transition: background-color 0.5s ease-in-out;
-      &:hover {
-        background-color: var(--mathsoc-pink-4);
+      button {
+        width: max-content;
+        cursor: pointer;
+
+        background-color: transparent;
+        transition: background-color 0.1s ease-in-out;
+        &:hover {
+          background-color: var(--mathsoc-pink-4);
+        }
       }
     }
   }

--- a/public/assets/sass/admin/exam-bank.scss
+++ b/public/assets/sass/admin/exam-bank.scss
@@ -70,5 +70,15 @@ hr {
     label {
       font-size: 0.8em;
     }
+
+    .delete-btn {
+      width: max-content;
+
+      background-color: none;
+      transition: background-color 0.5s ease-in-out;
+      &:hover {
+        background-color: var(--mathsoc-pink-4);
+      }
+    }
   }
 }

--- a/public/assets/ts/admin/exam-bank/AddExamsEditor.tsx
+++ b/public/assets/ts/admin/exam-bank/AddExamsEditor.tsx
@@ -89,6 +89,10 @@ export const AddExamsEditor: React.FC = () => {
     }
   };
 
+  const deleteFile = (fileName: string) => {
+    setExamFiles(examFiles.filter((file) => file.file.name !== fileName));
+  };
+
   return (
     <div id="add-exams-editor">
       <ul id="pending-exams-list">
@@ -98,6 +102,7 @@ export const AddExamsEditor: React.FC = () => {
               key={file.file.name}
               file={file.file}
               updateExamConfig={updateExamConfig}
+              removeExam={() => deleteFile(file.file.name)}
             />
           );
         })}

--- a/public/assets/ts/admin/exam-bank/PendingExamItem.tsx
+++ b/public/assets/ts/admin/exam-bank/PendingExamItem.tsx
@@ -4,7 +4,8 @@ import { ExamConfig } from "./AddExamsEditor";
 export const PendingExamItem: React.FC<{
   file: File;
   updateExamConfig: (newConfig: Partial<ExamConfig>, filename: string) => void;
-}> = ({ file, updateExamConfig }) => {
+  removeExam: () => void;
+}> = ({ file, updateExamConfig, removeExam }) => {
   const [fileDepartment, fileCode, fileTerm, ...fileExamNameParts] =
     file.name.split(/[.-]/);
   const fileExamName = fileExamNameParts
@@ -109,10 +110,20 @@ export const PendingExamItem: React.FC<{
           }}
         ></input>
       </div>
-      <div className="exam-data">
-        <label>Remove from Upload?</label>
-        <button className="delete-btn" onClick={() => console.log("Delete ME")}>
-          X
+      <div className="remove-upload-btn">
+        <label>Remove Upload?</label>
+        <button
+          onClick={() => {
+            if (
+              window.confirm(
+                "Are you sure you want to remove this upload from staging?"
+              )
+            ) {
+              removeExam();
+            }
+          }}
+        >
+          x
         </button>
       </div>
     </li>

--- a/public/assets/ts/admin/exam-bank/PendingExamItem.tsx
+++ b/public/assets/ts/admin/exam-bank/PendingExamItem.tsx
@@ -109,6 +109,12 @@ export const PendingExamItem: React.FC<{
           }}
         ></input>
       </div>
+      <div className="exam-data">
+        <label>Remove from Upload?</label>
+        <button className="delete-btn" onClick={() => console.log("Delete ME")}>
+          X
+        </button>
+      </div>
     </li>
   );
 };


### PR DESCRIPTION
A quick fix to the exam upload screen, it now provides the ability for the user to delete uploaded exams from upload, using the power of closures (we love closures)

Still need to implement other things like the issue with exams overriding each other on upload and potential duplicate names in keys - not sure what to do about the latter but we can figure something out i guess.

Will resolve #292 