### PR TITLE
Add error page to exam bank only

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "type": "git",
     "url": "git+https://github.com/MathSoc/mathsoc-website.git"
   },
-  "author": "",
+  "author": "MathSoc",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/MathSoc/mathsoc-website/issues"

--- a/server/config/admin/admin-pages.json
+++ b/server/config/admin/admin-pages.json
@@ -3,21 +3,25 @@
     "title": "Page Editors",
     "ref": "/admin/editor",
     "view": "/admin/generic-editor",
-    "noRouting": true
+    "noRouting": true,
+    "renderInExamBankMode": true
   },
   {
     "title": "Exam Bank",
     "ref": "/admin/exam-bank",
-    "view": "/admin/exam-bank"
+    "view": "/admin/exam-bank",
+    "renderInExamBankMode": true
   },
   {
     "title": "Image Store",
     "ref": "/admin/image-store",
-    "view": "/admin/image-store"
+    "view": "/admin/image-store",
+    "renderInExamBankMode": true
   },
   {
     "title": "Documents",
     "ref": "/admin/documents",
-    "view": "/admin/documents"
+    "view": "/admin/documents",
+    "renderInExamBankMode": true
   }
 ]

--- a/server/config/authenticated-pages.json
+++ b/server/config/authenticated-pages.json
@@ -2,7 +2,8 @@
   {
     "title": "Exam Bank",
     "ref": "/resources/exam-bank",
-    "view": "/resources/exam-bank"
+    "view": "/resources/exam-bank",
+    "renderInExamBankMode": true
   },
   {
     "title": "Elections",

--- a/server/config/pages.json
+++ b/server/config/pages.json
@@ -132,7 +132,8 @@
   {
     "title": "Page Not Found",
     "ref": "/error",
-    "view": "/error"
+    "view": "/error",
+    "renderInExamBankMode": true
   },
   {
     "title": "Success!",

--- a/server/routes/controllers/page-loader.ts
+++ b/server/routes/controllers/page-loader.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import { ReadWriteController } from "../../api/controllers/read-write-controller";
 import { PageInflow, PageOutflow } from "../../types/routing.js";
 import tokens from "../../../config";
+import config from "../../../config";
 
 /**
  * Contains functions related to the construction of new page routes and the population of
@@ -28,6 +29,10 @@ export class PageLoader {
     middleware?: RequestHandler
   ): void {
     for (const page of pageArray) {
+      if (config.EXAM_BANK_ONLY && !page.renderInExamBankMode) {
+        continue;
+      }
+
       const routeHandler = async (req: Request, res: Response) => {
         const data = await this.getAllPageData(page, dataTransformer);
         res.render(`pages/${page.view}.pug`, data);

--- a/server/routes/public-routes.ts
+++ b/server/routes/public-routes.ts
@@ -1,12 +1,9 @@
 import express from "express";
 import pages from "../config/pages.json";
 import { PageLoader } from "./controllers/page-loader";
-import tokens from "../../config";
 
 const router = express.Router();
 
-if (!tokens.EXAM_BANK_ONLY) {
-  PageLoader.buildRoutes(pages, router, (page) => page);
-}
+PageLoader.buildRoutes(pages, router, (page) => page);
 
 export default router;

--- a/server/types/routing.ts
+++ b/server/types/routing.ts
@@ -12,6 +12,7 @@ export interface PageInflow {
     [key: string]: string | undefined;
   };
   children?: PageInflow[];
+  renderInExamBankMode?: boolean;
 }
 
 export interface PageOutflow {


### PR DESCRIPTION
Closes #302 by explicitly specifying which pages should be shown in exam bank only mode.

The prior approach was just to blanket not use any public routes, which meant that `/error` wasn't rendered. This caused infinite redirect loops :(