### PR TITLE
Handling numeric values in input forms

### DIFF
--- a/public/assets/ts/admin/page-editor/editor-nodes/EditorNode.tsx
+++ b/public/assets/ts/admin/page-editor/editor-nodes/EditorNode.tsx
@@ -6,6 +6,7 @@ import { EditorArrayNode } from "./EditorArrayNode";
 import { EditorNodeProps } from "./EditorNodeTemplate";
 import { EditorContext } from "../EditorV2";
 import { EditorImageNode } from "./EditorImageNode";
+import { EditorNumberNode } from "./EditorNumberNode";
 
 export const EditorNode: React.FC<EditorNodeProps & { value: any }> = (
   props
@@ -27,6 +28,8 @@ export const EditorNode: React.FC<EditorNodeProps & { value: any }> = (
   } else if (props.name === "lastMigrationId") {
     // @todo make a non-editable EditorNode child to display the time of last migration. That or display it by some other means.
     return null;
+  } else if (typeof value === "number") {
+    return <EditorNumberNode {...props} />;
   } else {
     return <EditorLabelNode {...props} />;
   }

--- a/public/assets/ts/admin/page-editor/editor-nodes/EditorNumberNode.tsx
+++ b/public/assets/ts/admin/page-editor/editor-nodes/EditorNumberNode.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { EditorNodeProps, EditorNodeTemplate } from "./EditorNodeTemplate";
+import { EditorContext } from "../EditorV2";
+
+export const EditorNumberNode: React.FC<EditorNodeProps> = (props) => {
+  const { path } = props;
+  const labelId = `${path.join(".")}-label`;
+  const { getDataValue, setDataValue } = React.useContext(EditorContext);
+
+  return (
+    <EditorNodeTemplate key={path.join("-")} labelId={labelId} {...props}>
+      <input
+        aria-labelledby={labelId}
+        className="editor-input"
+        type="number"
+        defaultValue={getDataValue(path)}
+        onChange={(event) => {
+          setDataValue(path, event.target.valueAsNumber);
+        }}
+      />
+    </EditorNodeTemplate>
+  );
+};


### PR DESCRIPTION
# Summary of changes
- Allowed the backend to properly handle numeric values in editor input forms.

# Resolved issues
- Resolved issue #208

# Demonstration of changes
- Go to http://localhost:3000/admin/editor?page=resources/meetings.json
- Initial value of Term
![image](https://github.com/user-attachments/assets/4c17c5e1-8d6f-4be2-ad42-8b9f9b0bf85c)
- Modified value of Term and successful edit message
![image](https://github.com/user-attachments/assets/6e955cd3-540f-44b6-8aef-45e5471e8b5f)
![image](https://github.com/user-attachments/assets/e7169507-191c-4396-8086-2ecd856080c6)