### PR TITLE
Separate row issue when 2 files of the same exam have different display status

### DIFF
--- a/public/assets/ts/exam-bank.ts
+++ b/public/assets/ts/exam-bank.ts
@@ -109,10 +109,35 @@ class ExamBankFrontend {
     const tableBody = this.getExamList().querySelector("tbody");
     const hiddenRow = tableBody.querySelector("#hidden-row");
 
+    // Construct a row for each exam
     for (const exam of exams) {
       const key = `${exam.department}-${exam.courseCode}-${exam.term}-${exam.type}`
                   .replace("hidden", "").trimEnd();
       let row = tableBody.querySelector(`#${key}`) as HTMLElement;
+
+      // Status (i.e. shown/hidden) of exam file and solution file
+      const examHidden = exam.examFile?.toLowerCase().includes("-hidden");
+      const solutionHidden = exam.solutionFile?.toLowerCase().includes("-hidden");
+
+      // Hide exam row
+      if (!this.isInAdmin) {
+        // examFile does not exist and solutionFile is hidden
+        if (examHidden === undefined && solutionHidden) {
+          continue;
+        }
+        // solutionFile does not exist and examFile is hidden
+        if (solutionHidden === undefined && examHidden) {
+          continue;
+        }
+        // both files do not exist
+        if (examHidden === undefined && solutionHidden === undefined) {
+          continue;
+        }
+        // both files are hidden
+        if (examHidden && solutionHidden) {
+          continue;
+        }
+      }
 
       // If the row for this exam wasn't already created, then create a new row for this exam
       // Otherwise, just update the row data with the other file for this same exam
@@ -138,11 +163,7 @@ class ExamBankFrontend {
         row = newRow;
       }
 
-      const examHidden = exam.examFile?.toLowerCase().includes("-hidden");
-      const solutionHidden = exam.solutionFile
-        ?.toLowerCase()
-        .includes("-hidden");
-
+      // Manage status of download button
       if (exam.examFile && (this.isInAdmin || !examHidden)) {
         row.querySelector(".exam-download").classList.add("active");
       }


### PR DESCRIPTION
# Summary of changes
- When the exam file and the solution file of the same exam have different display status (i.e hidden - shown, shown - hidden), there will still be only 1 row for that exam.
- The action icons always show up for both Exam Actions and Solution Actions, regardless of whether the corresponding file actually exists.

# Issues resolved
- Resolved issue #301 

# Note
- I couldn't come up with a nice way to make the action icons only show up when the corresponding file exists, without making it overly messy. But even if the action icons show up for non-existent files, the actual actions wouldn't be triggered anyway, so I thought we could leave that as is.
- I also find the line `row.querySelector(".${type}-actions").classList.add("hidden")` in the original code to be not very great, since the icons are hidden but the functionalities are still there, as in the admin can still click on the invisible action buttons and change file status/delete file.
- That being said, I'm willing to work on it if you do have a good idea.