### PR TITLE
Keying Pending Exam Items and Concatenation

### DIFF
--- a/public/assets/ts/admin/exam-bank/AddExamsEditor.tsx
+++ b/public/assets/ts/admin/exam-bank/AddExamsEditor.tsx
@@ -12,15 +12,18 @@ export interface ExamConfig {
 
 type PendingExam = ExamConfig & {
   file: File;
+  keyStr: string;
 };
 
 export const AddExamsEditor: React.FC = () => {
   const [examFiles, setExamFiles] = useState<PendingExam[]>([]);
   const inputElement = useRef<HTMLInputElement>(null);
 
+  const [keyGen, setKeyGen] = useState<number>(0);
+
   const updateExamConfig = useCallback(
-    (newConfig: Partial<ExamConfig>, filename: string) => {
-      const file = examFiles.find((f) => f.file.name === filename);
+    (newConfig: Partial<ExamConfig>, fileKey: string) => {
+      const file = examFiles.find((f) => f.keyStr === fileKey);
       file.department = newConfig.department || file.department;
       file.courseCode = newConfig.courseCode || file.courseCode;
       file.termNumber = newConfig.termNumber || file.termNumber;
@@ -33,14 +36,17 @@ export const AddExamsEditor: React.FC = () => {
   const updateFiles = () => {
     if (inputElement.current?.files) {
       setExamFiles(
-        Array.from(inputElement.current.files).map((file) => ({
-          file,
-          department: "",
-          courseCode: "",
-          termNumber: "",
-          examType: "",
-          isSolution: false,
-        }))
+        examFiles.concat(
+          Array.from(inputElement.current.files).map((file) => ({
+            file,
+            keyStr: `${file.name}${(setKeyGen(keyGen + 1), keyGen)}`,
+            department: "",
+            courseCode: "",
+            termNumber: "",
+            examType: "",
+            isSolution: false,
+          }))
+        )
       );
     }
   };
@@ -89,8 +95,8 @@ export const AddExamsEditor: React.FC = () => {
     }
   };
 
-  const deleteFile = (fileName: string) => {
-    setExamFiles(examFiles.filter((file) => file.file.name !== fileName));
+  const deleteFile = (fileKey: string) => {
+    setExamFiles(examFiles.filter((file) => file.keyStr !== fileKey));
   };
 
   return (
@@ -99,10 +105,11 @@ export const AddExamsEditor: React.FC = () => {
         {examFiles.map((file) => {
           return (
             <PendingExamItem
-              key={file.file.name}
+              key={file.keyStr}
+              keyStr={file.keyStr}
               file={file.file}
               updateExamConfig={updateExamConfig}
-              removeExam={() => deleteFile(file.file.name)}
+              removeExam={() => deleteFile(file.keyStr)}
             />
           );
         })}
@@ -124,6 +131,7 @@ export const AddExamsEditor: React.FC = () => {
         accept="application/pdf"
         multiple
         onChange={updateFiles}
+        onClick={() => (inputElement.current.value = "")}
         ref={inputElement}
       />
     </div>

--- a/public/assets/ts/admin/exam-bank/PendingExamItem.tsx
+++ b/public/assets/ts/admin/exam-bank/PendingExamItem.tsx
@@ -3,9 +3,10 @@ import { ExamConfig } from "./AddExamsEditor";
 
 export const PendingExamItem: React.FC<{
   file: File;
-  updateExamConfig: (newConfig: Partial<ExamConfig>, filename: string) => void;
+  keyStr: string;
+  updateExamConfig: (newConfig: Partial<ExamConfig>, fileKey: string) => void;
   removeExam: () => void;
-}> = ({ file, updateExamConfig, removeExam }) => {
+}> = ({ file, keyStr, updateExamConfig, removeExam }) => {
   const [fileDepartment, fileCode, fileTerm, ...fileExamNameParts] =
     file.name.split(/[.-]/);
   const fileExamName = fileExamNameParts
@@ -27,7 +28,7 @@ export const PendingExamItem: React.FC<{
   const updateStringConfig = (
     target: HTMLInputElement,
     field: keyof ExamConfig,
-    filename: string
+    keyStr: string
   ) => {
     if (target.value === "") {
       target.classList.add("invalid");
@@ -35,7 +36,7 @@ export const PendingExamItem: React.FC<{
       target.classList.remove("invalid");
     }
 
-    updateExamConfig({ [field]: target.value }, filename);
+    updateExamConfig({ [field]: target.value }, keyStr);
   };
 
   // set all fields to defaults
@@ -48,7 +49,7 @@ export const PendingExamItem: React.FC<{
         examType: examType.replace(" ", "-"),
         isSolution: isSolution,
       },
-      file.name
+      keyStr
     );
   });
 
@@ -62,7 +63,7 @@ export const PendingExamItem: React.FC<{
           placeholder="MATH"
           onChange={(e) => {
             setDepartment(e.target.value);
-            updateStringConfig(e.target, "department", file.name);
+            updateStringConfig(e.target, "department", keyStr);
           }}
         ></input>
       </div>
@@ -73,7 +74,7 @@ export const PendingExamItem: React.FC<{
           placeholder="135"
           onChange={(e) => {
             setCourseCode(e.target.value);
-            updateStringConfig(e.target, "courseCode", file.name);
+            updateStringConfig(e.target, "courseCode", keyStr);
           }}
         ></input>
       </div>
@@ -84,7 +85,7 @@ export const PendingExamItem: React.FC<{
           placeholder="1235"
           onChange={(e) => {
             setTermNumber(e.target.value);
-            updateStringConfig(e.target, "termNumber", file.name);
+            updateStringConfig(e.target, "termNumber", keyStr);
           }}
         ></input>
       </div>
@@ -95,7 +96,7 @@ export const PendingExamItem: React.FC<{
           placeholder="Midterm"
           onChange={(e) => {
             setExamType(e.target.value);
-            updateStringConfig(e.target, "examType", file.name);
+            updateStringConfig(e.target, "examType", keyStr);
           }}
         ></input>
       </div>
@@ -106,7 +107,7 @@ export const PendingExamItem: React.FC<{
           type="checkbox"
           onChange={(e) => {
             setIsSolution(e.target.checked);
-            updateExamConfig({ isSolution: e.target.checked }, file.name);
+            updateExamConfig({ isSolution: e.target.checked }, keyStr);
           }}
         ></input>
       </div>


### PR DESCRIPTION
This PR should hopefully resolve #293 and #296 
- Added `keyStr` parameter to `PendingExam` as an unique key to each file in the frontend. Added an extra state to assign keys by way of increasing counter (a very low tech solution)
- Replaced all references that I can see to the file name to the new `keyStr` parameter

- Enabled concatenation of pending exam uploads when adding files, simply by setting the new array to a concatenated version rather than direct overriding
- Enabled uploading of the same file consecutively by adding `onClick = { () => inputElement.current.value = '' }`. Supposedly previously if you upload the same file(s) twice in a row it doesn't count as a change and doesn't trigger the event. This clearing ensures the event gets triggered.