### PR TITLE
316 exam bank fix term name of pre 1999 exams

### DIFF
--- a/server/api/controllers/term-name-controller.ts
+++ b/server/api/controllers/term-name-controller.ts
@@ -37,10 +37,33 @@ export class TermNameController {
     }
   }
 
+  static convertTermCodeToTermName(termCode: string) {
+    // termCodes are either in the format of abcd or bcd.
+    // assuming that a term code that starts with "2" i.e: 2bcd is a year in 2100
+    // bc refers to the year XXbc
+    let term = parseInt(termCode);
+    let termYear = 1900;
+    while (term > 1000) {
+      termYear += 100;
+      term -= 1000;
+    }
+    let monthNum = term % 10; // in theory, termCodes should always end in either 1, 5, or 9
+    let season = "FALL";
+    if (monthNum == 1) {
+      season = "WINTER";
+    } else if (monthNum == 5) {
+      season = "SPRING";
+    }
+    term /= 10; // get rid of the ones digit
+    term = Math.trunc(term);
+    termYear += term;
+    return season + " " + termYear;
+  }
+
   static getTermNameFromTermCode(termCode: string) {
     const terms = this.getTermsFile();
     const target = terms.find((item) => item.termCode === termCode);
-    return target?.name ?? termCode;
+    return target?.name ?? this.convertTermCodeToTermName(termCode);
   }
 
   static async overwriteTermsFile() {

--- a/server/api/controllers/term-name-controller.ts
+++ b/server/api/controllers/term-name-controller.ts
@@ -60,6 +60,7 @@ export class TermNameController {
     }
     term /= 10; // get rid of the ones digit
     term = Math.trunc(term);
+    termYear += term;
     const termName = season + " " + termYear;
 
     // Cache the result

--- a/server/api/controllers/term-name-controller.ts
+++ b/server/api/controllers/term-name-controller.ts
@@ -6,6 +6,7 @@ import tokens from "../../../config";
 
 export class TermNameController {
   static logger = new Logger("Term Name Controller");
+  static termCache = new Map<string, string>(); // cache of termCodes
 
   static async getTermNames(): Promise<Term[]> {
     const url = `${tokens.WATERLOO_OPEN_API_BASE_URL}/Terms`;
@@ -38,6 +39,9 @@ export class TermNameController {
   }
 
   static convertTermCodeToTermName(termCode: string) {
+    if (this.termCache.has(termCode)) {
+      return this.termCache.get(termCode); // Return from cache
+    }
     // termCodes are either in the format of abcd or bcd.
     // assuming that a term code that starts with "2" i.e: 2bcd is a year in 2100
     // bc refers to the year XXbc
@@ -56,8 +60,12 @@ export class TermNameController {
     }
     term /= 10; // get rid of the ones digit
     term = Math.trunc(term);
-    termYear += term;
-    return season + " " + termYear;
+    const termName = season + " " + termYear;
+
+    // Cache the result
+    this.termCache.set(termCode, termName);
+
+    return termName;
   }
 
   static getTermNameFromTermCode(termCode: string) {


### PR DESCRIPTION
This issue seems to have been resolved with the new function I have added - titled convertTermCodeToTermName in term-name-controller.ts!

The one thing that came up during testing was that the term code 1071 was mapped to Winter 2007 - could this be confirmed to be correct or not? Since the exam that I downloaded off of the MathSoc website (amath-231-1071-final.pdf) seemed to be for Fall 2003.

The other mappings seemed to work fine. The format that I believed to be correct and implemented was as follows
1. termCodes are either in the format of abcd or bcd.
2. assuming that a term code that starts with "2" i.e: 2bcd is a year in 2100
3. bc refers to the year XXbc
4. d refers to the month (and correspondingly, the term) - 1 means winter, 5 means spring, 9 means fall.