### PR TITLE
Add feature to allow admins to rename exam types

### DIFF
--- a/server/api/admin/index.ts
+++ b/server/api/admin/index.ts
@@ -141,4 +141,24 @@ router.get("/documents", (req: Request, res: Response) => {
   ReadWriteAPIController.getJSONDataPath(DOCUMENT_URL, res);
 });
 
+router.post("/exams/:examName/rename-type", (req: Request, res: Response) => {
+  try {
+    const { newType } = req.body;
+    if (!newType || typeof newType !== "string") {
+      res.status(400).end();
+      return;
+    }
+
+    ExamBankController.renameExamType(req.params.examName, newType);
+    res.status(200).end();
+  } catch (e) {
+    if (e instanceof Error && e.message.includes("not found")) {
+      res.status(404).end();
+    } else {
+      console.error("Error renaming exam:", e);
+      res.status(500).end();
+    }
+  }
+});
+
 export default router;


### PR DESCRIPTION
# Feat 
- Add frontend interface for renaming exam types via click interaction
- Implemented backend POST endpoint /api/admin/exams/:examName/rename-type

LMK your thoughts– tried to be consistent w/ existing code throughout to the best of my ability.

Fixes:
#313 and #314

# Tests
- None


