### PR TITLE
Update website requirements

### DIFF
--- a/public/assets/sass/pages/get-involved/council.scss
+++ b/public/assets/sass/pages/get-involved/council.scss
@@ -31,6 +31,7 @@ section {
 }
 
 .mailing-list-form {
+  display: none;
   max-width: var(--content-width);
   margin: 40px auto;
   padding: 0;


### PR DESCRIPTION
Reduces the number of blockers we have pre-launch by removing the council mailing list feature. 

If you're looking at this wondering why this was removed, try implementing it! It's... worth finding alternatives for. Look into Google Groups role management and the associated APIs, that should give you a good starting place.