### PR TITLE
Remove 'Term social events' from navbar (closes #237)

### DIFF
--- a/server/config/navbar.json
+++ b/server/config/navbar.json
@@ -28,10 +28,6 @@
         "ref": "/services/mathsoc-office"
       },
       {
-        "title": "Term social events",
-        "ref": "/"
-      },
-      {
         "title": "Student services",
         "ref": "/services/student-services"
       }


### PR DESCRIPTION
This update removes outdated term social events from the website. No functional changes were made, just content cleanup.