### PR TITLE
319 replacing redundant waterloo api logic in relation to converttermcodetotermname

### DIFF
--- a/server/api/controllers/exam-bank-controller.ts
+++ b/server/api/controllers/exam-bank-controller.ts
@@ -138,9 +138,6 @@ export class ExamBankController {
    * Gets an array of every exam currently in the exam list folder
    */
   private static async generateExamsList(): Promise<Exam[]> {
-    // currently this doesn't work
-    // await this.validateTerms();
-
     const examFiles: Dirent[] = readdirSync("public/exams", {
       withFileTypes: true,
     });
@@ -214,27 +211,5 @@ export class ExamBankController {
         throw new Error("Unreachable code reached");
       }
     }
-  }
-
-  private static async validateTerms() {
-    const examFiles: Dirent[] = readdirSync("public/exams", {
-      withFileTypes: true,
-    });
-
-    let valid = true;
-    for (const exam of examFiles) {
-      const parts = exam.name.split("-");
-      const term = parts[2].padStart(4, "0");
-
-      const isValidTerm = TermNameController.validateTerm(term);
-      if (!isValidTerm) {
-        valid = false;
-        break;
-      }
-    }
-    // doesn't work currently
-    // if (!valid) {
-    //   await TermNameController.overwriteTermsFile();
-    // }
   }
 }

--- a/server/api/controllers/exam-bank-controller.ts
+++ b/server/api/controllers/exam-bank-controller.ts
@@ -138,7 +138,8 @@ export class ExamBankController {
    * Gets an array of every exam currently in the exam list folder
    */
   private static async generateExamsList(): Promise<Exam[]> {
-    await this.validateTerms();
+    // currently this doesn't work
+    // await this.validateTerms();
 
     const examFiles: Dirent[] = readdirSync("public/exams", {
       withFileTypes: true,
@@ -231,9 +232,9 @@ export class ExamBankController {
         break;
       }
     }
-
-    if (!valid) {
-      await TermNameController.overwriteTermsFile();
-    }
+    // doesn't work currently
+    // if (!valid) {
+    //   await TermNameController.overwriteTermsFile();
+    // }
   }
 }

--- a/server/api/controllers/term-name-controller.ts
+++ b/server/api/controllers/term-name-controller.ts
@@ -38,7 +38,7 @@ export class TermNameController {
     }
   }
 
-  static convertTermCodeToTermName(termCode: string) {
+  static getTermNameFromTermCode(termCode: string) {
     if (this.termCache.has(termCode)) {
       return this.termCache.get(termCode); // Return from cache
     }
@@ -67,12 +67,6 @@ export class TermNameController {
     this.termCache.set(termCode, termName);
 
     return termName;
-  }
-
-  static getTermNameFromTermCode(termCode: string) {
-    const terms = this.getTermsFile();
-    const target = terms.find((item) => item.termCode === termCode);
-    return target?.name ?? this.convertTermCodeToTermName(termCode);
   }
 
   static async overwriteTermsFile() {

--- a/server/api/controllers/term-name-controller.ts
+++ b/server/api/controllers/term-name-controller.ts
@@ -8,27 +8,6 @@ export class TermNameController {
   static logger = new Logger("Term Name Controller");
   static termCache = new Map<string, string>(); // cache of termCodes
 
-  // static async getTermNames(): Promise<Term[]> {
-  //   const url = `${tokens.WATERLOO_OPEN_API_BASE_URL}/Terms`;
-  //   const response = await fetch(new URL(url), {
-  //     method: "GET",
-  //     headers: {
-  //       "X-API-KEY": tokens.WATERLOO_OPEN_API_KEY as string,
-  //       "Content-Type": "application/json",
-  //     },
-  //   });
-
-  //   const terms: Term[] = await response.json();
-  //   return terms;
-  // }
-
-  static validateTerm(term: string): boolean {
-    const terms = this.getTermsFile();
-    const termCodes = terms.map((item) => item.termCode);
-
-    return termCodes.includes(term);
-  }
-
   static getTermsFile(): Term[] {
     try {
       const terms = fs.readFileSync("server/data/_hidden/term-list.json");
@@ -68,18 +47,4 @@ export class TermNameController {
 
     return termName;
   }
-
-  // static async overwriteTermsFile() {
-  //   try {
-  //     const terms = await this.getTermNames();
-  //     const url = "_hidden/term-list";
-  //     const fullPath = `server/data/${url}.json`;
-
-  //     fs.writeFileSync(fullPath, JSON.stringify(terms));
-  //     this.logger.info("Terms file rewritten");
-  //   } catch (err) {
-  //     this.logger.error("Could not rewrite terms file.");
-  //     this.logger.error(err);
-  //   }
-  // }
 }

--- a/server/api/controllers/term-name-controller.ts
+++ b/server/api/controllers/term-name-controller.ts
@@ -8,19 +8,19 @@ export class TermNameController {
   static logger = new Logger("Term Name Controller");
   static termCache = new Map<string, string>(); // cache of termCodes
 
-  static async getTermNames(): Promise<Term[]> {
-    const url = `${tokens.WATERLOO_OPEN_API_BASE_URL}/Terms`;
-    const response = await fetch(new URL(url), {
-      method: "GET",
-      headers: {
-        "X-API-KEY": tokens.WATERLOO_OPEN_API_KEY as string,
-        "Content-Type": "application/json",
-      },
-    });
+  // static async getTermNames(): Promise<Term[]> {
+  //   const url = `${tokens.WATERLOO_OPEN_API_BASE_URL}/Terms`;
+  //   const response = await fetch(new URL(url), {
+  //     method: "GET",
+  //     headers: {
+  //       "X-API-KEY": tokens.WATERLOO_OPEN_API_KEY as string,
+  //       "Content-Type": "application/json",
+  //     },
+  //   });
 
-    const terms: Term[] = await response.json();
-    return terms;
-  }
+  //   const terms: Term[] = await response.json();
+  //   return terms;
+  // }
 
   static validateTerm(term: string): boolean {
     const terms = this.getTermsFile();
@@ -69,17 +69,17 @@ export class TermNameController {
     return termName;
   }
 
-  static async overwriteTermsFile() {
-    try {
-      const terms = await this.getTermNames();
-      const url = "_hidden/term-list";
-      const fullPath = `server/data/${url}.json`;
+  // static async overwriteTermsFile() {
+  //   try {
+  //     const terms = await this.getTermNames();
+  //     const url = "_hidden/term-list";
+  //     const fullPath = `server/data/${url}.json`;
 
-      fs.writeFileSync(fullPath, JSON.stringify(terms));
-      this.logger.info("Terms file rewritten");
-    } catch (err) {
-      this.logger.error("Could not rewrite terms file.");
-      this.logger.error(err);
-    }
-  }
+  //     fs.writeFileSync(fullPath, JSON.stringify(terms));
+  //     this.logger.info("Terms file rewritten");
+  //   } catch (err) {
+  //     this.logger.error("Could not rewrite terms file.");
+  //     this.logger.error(err);
+  //   }
+  // }
 }


### PR DESCRIPTION
Commented out the functions that no longer worked due to the API not working. Appears to work normally on my local version! We might want to add in validation that works later, though.