### PR TITLE
fix(exam-table): prevent overflow on small screens by enabling horizontal scroll

### DIFF
--- a/public/assets/sass/mixins/_exam-bank-table.scss
+++ b/public/assets/sass/mixins/_exam-bank-table.scss
@@ -4,6 +4,12 @@
   text-align: left;
   border-collapse: collapse;
 
+  @media only screen and (max-width: 980px) {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
   @mixin match-filters($filter-classes) {
     tbody {
       tr:not(#{$filter-classes}) {


### PR DESCRIPTION
### Summary

On viewports narrower than 980px, the table was overflowing the screen. These changes add a responsive media query so that the table becomes a block-level element with `overflow-x: auto`, allowing horizontal scrolling instead of forcing the layout to expand.


